### PR TITLE
Switch from unreliable to more stable Travis variable.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ before_install:
 before_script:
     # Print build info.
     - echo $TRAVIS_COMMIT
+    - echo $TRAVIS_BRANCH
     - echo $TRAVIS_TAG
     - echo $TRAVIS_BRANCH
     - echo $TRAVIS_BUILD_NUMBER

--- a/check_signed_off.sh
+++ b/check_signed_off.sh
@@ -12,9 +12,9 @@ esac
 if [ -n "$1" ]
 then
     COMMIT_RANGE="$1"
-elif [ -n "$TRAVIS_COMMIT_RANGE" ]
+elif [ -n "$TRAVIS_BRANCH" ]
 then
-    COMMIT_RANGE="$TRAVIS_COMMIT_RANGE"
+    COMMIT_RANGE="$TRAVIS_BRANCH..FETCH_HEAD"
 else
     # Just check previous commit if nothing else is specified.
     COMMIT_RANGE=HEAD~1..HEAD


### PR DESCRIPTION
TRAVIS_COMMIT_RANGE seems to have many people complaining about it
online, and we've had cases where it fails to check pull requests
properly. Use TRAVIS_BRANCH and Git FETCH_HEAD instead, which should
be more stable. See the discussion here:
https://github.com/travis-ci/travis-ci/issues/1719

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>