### PR TITLE
Do license checks between main Travis branch and current HEAD.

### DIFF
--- a/check_signed_off.sh
+++ b/check_signed_off.sh
@@ -20,7 +20,8 @@ else
     COMMIT_RANGE=HEAD~1..HEAD
 fi
 
-echo "Checking range: ${COMMIT_RANGE}"
+echo "Checking range: ${COMMIT_RANGE}:"
+git log "$COMMIT_RANGE"
 
 commits="$(git rev-list --no-merges "$COMMIT_RANGE")"
 notsigned=

--- a/check_signed_off.sh
+++ b/check_signed_off.sh
@@ -14,7 +14,7 @@ then
     COMMIT_RANGE="$1"
 elif [ -n "$TRAVIS_BRANCH" ]
 then
-    COMMIT_RANGE="$TRAVIS_BRANCH..FETCH_HEAD"
+    COMMIT_RANGE="$TRAVIS_BRANCH..HEAD"
 else
     # Just check previous commit if nothing else is specified.
     COMMIT_RANGE=HEAD~1..HEAD

--- a/license_test.go
+++ b/license_test.go
@@ -40,7 +40,7 @@ func expectFailure(t *testing.T) {
 	}
 }
 
-func TestLicenses(t *testing.T) {
+func TestMockLicenses(t *testing.T) {
 	hierarchy := path.Join("tmp/src", packageLocation)
 
 	// Create whole src structure. This is just in case this is tested out-
@@ -108,4 +108,8 @@ func TestLicenses(t *testing.T) {
 		var mock mockT = mockT{t}
 		CheckLicenses(&mock)
 	}()
+}
+
+func TestLicenses(t *testing.T) {
+	CheckLicenses(t)
 }


### PR DESCRIPTION
```
commit 8741aaa9c32e2110a9bf084f16c2b6693dd1f105
Author: Kristian Amlie <kristian.amlie@mender.io>
Date:   Tue Sep 27 13:40:45 2016

    Do license checks between main Travis branch and current HEAD.
    
    On master this is likely to give a zero range, but this is ok, since
    testing a range for signoff is useless on master (what would you do
    about it?). However, for pull requests it will be the range of new
    commits being introduced, which is what we want.
    
    Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>

commit 93c4fc7f55e56c306baea8bdd0803104c4c16da3
Author: Kristian Amlie <kristian.amlie@mender.io>
Date:   Tue Sep 27 13:40:26 2016

    Test actual licenses, not just mock licenses.
    
    Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>

commit 289616786a93f7125d8f58f6ecaa3760625adf24
Author: Kristian Amlie <kristian.amlie@mender.io>
Date:   Tue Sep 27 13:39:28 2016

    Include exactly the commits we test in check_signed_off.sh.
    
    It's sometimes hard to tell from Travis output.
    
    Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>
```