### PR TITLE
Add SetLicenseFileForDependency().

### DIFF
--- a/licenses.go
+++ b/licenses.go
@@ -33,6 +33,14 @@ type TSubset interface {
 	Log(args ...interface{})
 }
 
+var known_license_files []string = []string{}
+
+// Specify a license file for a dependency explicitly, avoiding the check for
+// common license file names.
+func SetLicenseFileForDependency(license_file string) {
+	known_license_files = append(known_license_files, "--add-license="+license_file)
+}
+
 func CheckLicenses(t TSubset) {
 	pathToTool, err := locatePackage()
 	if err != nil {
@@ -40,7 +48,6 @@ func CheckLicenses(t TSubset) {
 	}
 
 	checks := []string{
-		"check_license.sh",
 		"check_license_go_code.sh",
 		"check_signed_off.sh",
 	}
@@ -53,6 +60,14 @@ func CheckLicenses(t TSubset) {
 			t.Log(err.Error())
 			t.Fatal(string(output[:]))
 		}
+	}
+
+	cmdString := path.Join(pathToTool, "check_license.sh")
+	cmd := exec.Command(cmdString, known_license_files...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Log(err.Error())
+		t.Fatal(string(output[:]))
 	}
 }
 


### PR DESCRIPTION
Call it in cases where the license is inside a file without a standard
license file name.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>