### PR TITLE
Refix Travis references to branches and tags.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,16 @@ before_script:
     - echo $TRAVIS_BUILD_NUMBER
     - echo $TRAVIS_REPO_SLUG
 
+    # Rename the branch we're on, so that it's not in the way for the
+    # subsequent fetch. It's ok if this fails, it just means we're not on any
+    # branch.
+    - git branch -m temp-branch || true
+    # Git trick: Fetch directly into our local branches instead of remote
+    # branches.
+    - git fetch origin 'refs/heads/*:refs/heads/*'
+    # Get last remaining tags, if any.
+    - git fetch --tags origin
+
     # Test if code was formatted with 'go fmt'
     # Command will format code and return modified files
     # fail if any have been modified.

--- a/check_signed_off.sh
+++ b/check_signed_off.sh
@@ -14,7 +14,7 @@ then
     COMMIT_RANGE="$1"
 elif [ -n "$TRAVIS_BRANCH" ]
 then
-    COMMIT_RANGE="origin/$TRAVIS_BRANCH..HEAD"
+    COMMIT_RANGE="$TRAVIS_BRANCH..HEAD"
 else
     # Just check previous commit if nothing else is specified.
     COMMIT_RANGE=HEAD~1..HEAD


### PR DESCRIPTION
Referring to origin/* is wrong, because that doesn't work for tags.
In fact, there is no way we can refer to tags other than a bare
string, and since we need to use branches and tags interchangably, we
have to make branches follow the same pattern.

Therefore, we have to do the Git magic in this patch to fetch the
branches into local branches with bare names.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>