### PR TITLE
Make it possible for check_commits.sh to take more than one argument.

### DIFF
--- a/check_commits.sh
+++ b/check_commits.sh
@@ -9,10 +9,7 @@ case "$1" in
         ;;
 esac
 
-if [ -n "$1" ]
-then
-    COMMIT_RANGE="$1"
-elif [ -n "$TRAVIS_BRANCH" ]
+if [ -n "$TRAVIS_BRANCH" ]
 then
     COMMIT_RANGE="$TRAVIS_BRANCH..HEAD"
 else
@@ -20,10 +17,16 @@ else
     COMMIT_RANGE=HEAD~1..HEAD
 fi
 
-echo "Checking range: ${COMMIT_RANGE}:"
-git log "$COMMIT_RANGE"
-
-commits="$(git rev-list --no-merges "$COMMIT_RANGE")"
+if [ -n "$1" ]
+then
+    echo "Checking range: $@:"
+    git log "$@"
+    commits="$(git rev-list --no-merges "$@")"
+else
+    echo "Checking range: ${COMMIT_RANGE}:"
+    git log "$COMMIT_RANGE"
+    commits="$(git rev-list --no-merges "$COMMIT_RANGE")"
+fi
 notvalid=
 for i in $commits
 do


### PR DESCRIPTION
This is necessary when specifying branches of the form:

  git rev-list HEAD --not origin/master

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>