### PR TITLE
Update license check to check for specific copyright year.

### DIFF
--- a/check_license_go_code.sh
+++ b/check_license_go_code.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
 cat > license.tmp <<EOF
-// Copyright 2017 Northern.tech AS
-//
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
 //    You may obtain a copy of the License at
@@ -16,16 +14,29 @@ cat > license.tmp <<EOF
 //    limitations under the License.
 EOF
 lines=$(cat license.tmp | wc -l)
+# we need to add two extra lines missing from the license preamble
+# // Copyright <copyrigt_year> Northern.tech AS
+# //
+lines=$(($lines + 2))
 
 ret=0
 for each in $(find . -type f \( ! -regex '.*/\..*' ! -path "./Godeps/*" ! -path "./vendor/*" -name '*.go' \)); do
-  echo "Checking $each for correct license header"
-  head -n $lines $each | diff -qu license.tmp - > /dev/null
+  modified_year=$(git log -n1 --format=%ad --date=format:%Y -- $each)
+  
+  echo "Checking $each for correct license header; last modified in $modified_year"
+
+  head -n $lines $each | tail -n +3 | diff -qu license.tmp - > /dev/null
   if [ ! "$?" -eq "0" ]; then
     echo "!!! FAILED license check on $each"
     ret=1
   else
-    echo "License check passed on $each"
+    copyright_modified=$(echo "// Copyright <copyright_year> Northern.tech AS" | sed "s/<copyright_year>/$modified_year/g")
+    copyright_file=$(head -n 1 $each)
+    if [ "$copyright_modified" == "$copyright_file" ]; then
+      echo "License check passed on $each"
+    else
+      echo "!!! FAILED license check on $each; make sure copyright year matches last modified year of the file"
+    fi
   fi
 done
 


### PR DESCRIPTION
License test is checking now when the source file was modified and
makes sure the last modification date matches the copyright information
inside the source file.
This way all the modified files need to have the license updated, but
the ones which are not modified can stay with the previous copyright
information.

Changelog: None

Signed-off-by: Marcin Pasinski <marcin.pasinski@northern.tech>