### PR TITLE
Use --follow when checking last modified year of file.

### DIFF
--- a/check_license_go_code.sh
+++ b/check_license_go_code.sh
@@ -21,7 +21,7 @@ lines=$(($lines + 2))
 
 ret=0
 for each in $(find . -type f \( ! -regex '.*/\..*' ! -path "./Godeps/*" ! -path "./vendor/*" -name '*.go' \)); do
-  modified_year=$(git log -n1 --format=%ad --date=format:%Y -- $each)
+  modified_year=$(git log --follow -n1 --format=%ad --date=format:%Y -- $each)
   
   echo "Checking $each for correct license header; last modified in $modified_year"
 


### PR DESCRIPTION
This avoids a couple of pitfalls:

* Doesn't include merges in the candidates for last modified commit

* Tracks renames correctly, not including files as candidates that
  have merely been moved, but not changed

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>