### PR TITLE
Set checksum filepath to default value

### DIFF
--- a/check_license.sh
+++ b/check_license.sh
@@ -21,7 +21,7 @@ fi
 # Check license of dependencies.
 ################################################################################
 
-CHKSUM_FILE=LIC_FILES_CHKSUM.sha256
+CHKSUM_FILE=${CHKSUM_FILE:-LIC_FILES_CHKSUM.sha256}
 
 while [ -n "$1" ]; do
     case "$1" in


### PR DESCRIPTION
Made it possible to modify the CHKSUM_FILE variable if it's defined in
the environment.

Signed-off-by: Alf-Rune Siqveland <alf.rune@northern.tech>