### PR TITLE
Create Pipeline(s) for mendertesting  repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+# Coverage report
+coverage.txt

--- a/.gitlab-ci-check-commits.yml
+++ b/.gitlab-ci-check-commits.yml
@@ -1,0 +1,23 @@
+
+stages:
+  - test
+
+test:check-commits:
+  image: alpine
+  stage: test
+  before_script:
+    # Install dependencies
+    - apk add --no-cache git bash
+    # Rename the branch we're on, so that it's not in the way for the
+    # subsequent fetch. It's ok if this fails, it just means we're not on any
+    # branch.
+    - git branch -m temp-branch || true
+    # Git trick: Fetch directly into our local branches instead of remote
+    # branches.
+    - git fetch origin 'refs/heads/*:refs/heads/*'
+    # Get last remaining tags, if any.
+    - git fetch --tags origin
+    - git clone http://github.com/mendersoftware/mendertesting /tmp/mendertesting
+  script:
+    # Check commit compliance.
+    - /tmp/mendertesting/check_commits.sh

--- a/.gitlab-ci-check-license.yml
+++ b/.gitlab-ci-check-license.yml
@@ -1,0 +1,23 @@
+
+stages:
+  - test
+
+test:check-license:
+  image: alpine
+  stage: test
+  before_script:
+    # Install dependencies
+    - apk add --no-cache git bash perl-utils
+    # Rename the branch we're on, so that it's not in the way for the
+    # subsequent fetch. It's ok if this fails, it just means we're not on any
+    # branch.
+    - git branch -m temp-branch || true
+    # Git trick: Fetch directly into our local branches instead of remote
+    # branches.
+    - git fetch origin 'refs/heads/*:refs/heads/*'
+    # Get last remaining tags, if any.
+    - git fetch --tags origin
+    - git clone http://github.com/mendersoftware/mendertesting /tmp/mendertesting
+  script:
+    # Check licenses
+    - /tmp/mendertesting/check_license.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,22 +1,16 @@
-language: go
+include:
+  - local: '.gitlab-ci-check-commits.yml'
+  - local: '.gitlab-ci-check-license.yml'
 
-# Golang version matrix
-go:
-    - 1.8
+stages:
+  - test
+  - publish
 
-before_install:
-    # Install code coverage / coveralls tooling
-    - go get -u github.com/axw/gocov/gocov
-    - go get -u golang.org/x/tools/cmd/cover
+test:unit:
+  image: golang:1.12
+  stage: test
 
-before_script:
-    # Print build info.
-    - echo $TRAVIS_COMMIT
-    - echo $TRAVIS_TAG
-    - echo $TRAVIS_BRANCH
-    - echo $TRAVIS_BUILD_NUMBER
-    - echo $TRAVIS_REPO_SLUG
-
+  before_script:
     # Rename the branch we're on, so that it's not in the way for the
     # subsequent fetch. It's ok if this fails, it just means we're not on any
     # branch.
@@ -27,6 +21,16 @@ before_script:
     # Get last remaining tags, if any.
     - git fetch --tags origin
 
+    # Prepare GO path
+    - mkdir -p /go/src/github.com/mendersoftware
+    - cp -r $CI_PROJECT_DIR /go/src/github.com/mendersoftware/mendertesting
+    - cd /go/src/github.com/mendersoftware/mendertesting
+
+    # Install code coverage / coveralls tooling
+    - go get -u github.com/axw/gocov/gocov
+    - go get -u golang.org/x/tools/cmd/cover
+
+  script:
     # Test if code was formatted with 'go fmt'
     # Command will format code and return modified files
     # fail if any have been modified.
@@ -35,7 +39,6 @@ before_script:
     # Perform static code analysys
     - go vet `go list ./... | grep -v vendor`
 
-script:
     # go list supply import paths for all sub directories.
     # Exclude vendor directory, we don't want to run tests and coverage for all dependencies every time,
     # also including their coverage may introduce to much noice. Concentrate on the coverage of local packages.
@@ -43,9 +46,20 @@ script:
     # Test packages pararell (xargs -P)
     - go list ./... | grep -v vendor | xargs -n1 -I {} -P 4 go test -v -covermode=atomic -coverprofile=../../../{}/coverage.txt {} || exit $?
 
-    # Compile binary
-    - go build
+    # Collect coverage report
+    - cp coverage.txt $CI_PROJECT_DIR/
 
-after_success:
-    # Integrate with https://codecov.io
-    - bash <(curl -s https://codecov.io/bash)
+  artifacts:
+    expire_in: 2w
+    paths:
+      - coverage.txt
+
+publish:tests:
+  image: alpine
+  stage: publish
+  before_script:
+    - apk add --no-cache bash curl findutils git
+  dependencies:
+    - test:unit
+  script:
+    - bash -c "bash <(curl -s https://codecov.io/bash) -Z"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Testing package for Golang
-[![Build Status](https://travis-ci.org/mendersoftware/mendertesting.svg?branch=master)](https://travis-ci.org/mendersoftware/mendertesting)
+[![Build Status](https://gitlab.com/Northern.tech/Mender/mendertesting/badges/master/pipeline.svg)](https://gitlab.com/Northern.tech/Mender/mendertesting/pipelines)
 [![codecov](https://codecov.io/gh/mendersoftware/mendertesting/branch/master/graph/badge.svg)](https://codecov.io/gh/mendersoftware/mendertesting)
 [![Godoc](http://img.shields.io/badge/godoc-reference-blue.svg?style=flat)](https://godoc.org/github.com/mendersoftware/mendertesting)
 [![Go Report Card](https://goreportcard.com/badge/github.com/mendersoftware/mendertesting)](https://goreportcard.com/report/github.com/mendersoftware/mendertesting)


### PR DESCRIPTION
These independent check-commits and check-license pipelines are meant to
be included by any other GitLab Pipeline in the organization.

Note that from Travis to GitLab, the "go build" step has been removed.
This repo does not produce any binary so the build is unnecesary.

Changelog: None

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>