### PR TITLE
QA-111: Check signed commits on community repositories 

### DIFF
--- a/.gitlab-ci-check-commits-changelogs.yml
+++ b/.gitlab-ci-check-commits-changelogs.yml
@@ -1,0 +1,23 @@
+
+stages:
+  - test
+
+test:check-commits:
+  image: alpine
+  stage: test
+  before_script:
+    # Install dependencies
+    - apk add --no-cache git bash
+    # Rename the branch we're on, so that it's not in the way for the
+    # subsequent fetch. It's ok if this fails, it just means we're not on any
+    # branch.
+    - git branch -m temp-branch || true
+    # Git trick: Fetch directly into our local branches instead of remote
+    # branches.
+    - git fetch origin 'refs/heads/*:refs/heads/*'
+    # Get last remaining tags, if any.
+    - git fetch --tags origin
+    - git clone http://github.com/mendersoftware/mendertesting /tmp/mendertesting
+  script:
+    # Verify that the commits have a changelog.
+    - /tmp/mendertesting/check_commits.sh --changelogs

--- a/.gitlab-ci-check-commits-signoffs.yml
+++ b/.gitlab-ci-check-commits-signoffs.yml
@@ -1,0 +1,23 @@
+
+stages:
+  - test
+
+test:check-commits:
+  image: alpine
+  stage: test
+  before_script:
+    # Install dependencies
+    - apk add --no-cache git bash
+    # Rename the branch we're on, so that it's not in the way for the
+    # subsequent fetch. It's ok if this fails, it just means we're not on any
+    # branch.
+    - git branch -m temp-branch || true
+    # Git trick: Fetch directly into our local branches instead of remote
+    # branches.
+    - git fetch origin 'refs/heads/*:refs/heads/*'
+    # Get last remaining tags, if any.
+    - git fetch --tags origin
+    - git clone http://github.com/mendersoftware/mendertesting /tmp/mendertesting
+  script:
+    # Verify that the commits have signoffs.
+    - /tmp/mendertesting/check_commits.sh --signoffs


### PR DESCRIPTION
This is done through adding two flags to the chech_commits.sh script.
One for enabling the signature check, and one for enabling the Changelog check.

In the case that no flags are given, they will both be checked (The old
behaviour).

Also add the ability to pass these parameters to the
'.gitlab-ci-check-commits.yml' file through an environment variable
'MENDERTESTING_ARGS'.

Changelog: None

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>