### PR TITLE
QA-131: Add a .gitlab-ci file which can be included in other files

### DIFF
--- a/.gitlab-ci-check-python3-format.yml
+++ b/.gitlab-ci-check-python3-format.yml
@@ -1,0 +1,65 @@
+# .gitlab-ci-check-python3-format.yml
+#
+# This gitlab-ci file runs the Black code formatter https://github.com/psf/black
+# on the Python3 code in the repository, and fails the pipeline if the code is
+# not formatted according to standard Black formatting rules.
+#
+# Add it to the project in hand through Gitlab's include functionality
+# 
+# include:
+#   - project: 'Northern.tech/Mender/mendertesting'
+#     file: '.gitlab-ci-check-python3-format.yml'
+#
+# The formatter can be specified to only format Python code from specific
+# directories. This is done through adding the directories to the
+# 'FORMAT_DIRECTORIES' variable in a Gitlab file, whitespace separated if
+# multiple. If left empty, no filter will be applied.
+#
+# Example 'gitlab-ci.yml' addition:
+# variables:
+#    FORMAT_PYTHON3_DIRECTORIES: "some/project/repository/to/be/formatted/"
+#
+# Some things to consider before including this file. The Black code formatter
+# accepts a project-local configuration file
+# (https://github.com/psf/black#pyprojecttoml). This enables project specific
+# configuration of the Black tool.
+#
+# The only recommended parameter to specify is:
+# * The Python version
+#
+# The configuration parameters available match the command-line paramaters as listed here:
+#    https://github.com/psf/black#command-line-options
+#
+# Example 'pyproject.toml' file:
+#
+#[tool.black]
+# target-version = ['py38'] # If the project is using Python version 3.8
+# '''
+#
+
+stages:
+  - test
+
+test:check-python3-formatting:
+  image: debian
+  stage: test
+  variables:
+      BLACK_FORMATTER_VERSION: "19.10b0" # Hard-coded and unconfigurable
+  before_script:
+    # Install dependencies
+    - apt-get update
+    - apt-get install -yq python3 python3-pip git
+    - pip3 install black==$BLACK_FORMATTER_VERSION
+    # Rename the branch we're on, so that it's not in the way for the
+    # subsequent fetch. It's ok if this fails, it just means we're not on any
+    # branch.
+    - git branch -m temp-branch || true
+    # Git trick: Fetch directly into our local branches instead of remote
+    # branches.
+    - git fetch origin 'refs/heads/*:refs/heads/*'
+    # Get last remaining tags, if any.
+    - git fetch --tags origin
+    - git clone http://github.com/mendersoftware/mendertesting /tmp/mendertesting
+  script:
+    # Check that the Python code is formattet
+    - env /tmp/mendertesting/check_python_code_format

--- a/check_python_code_format
+++ b/check_python_code_format
@@ -1,0 +1,137 @@
+#! /bin/bash
+
+#
+# A simple script for verifying that all the commits in the PR-range has
+# the Python code correctly formatted with the Black code formatter.
+#
+# Usage:
+#   see --help
+#
+#
+set -e
+
+CODE_DIRECTORIES=${FORMAT_PYTHON3_DIRECTORIES:-"./"}
+
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        -h|--help)
+            echo "Usage: $(basename $0) [OPTIONS] <git-range>"
+            echo ""
+            echo "This script runs the Black formatter on all the Python code"
+            echo "it can find in each commit listed in the $COMMIT_RANGE,"
+            echo "and exits with exit-code 1 if any of the commits contain"
+            echo "code which is not formatted in accordance with Black's rules."
+            echo ""
+            echo "-d|--directory"
+            echo "  Adds the directory to the directories checked by Black"
+            echo ""
+            echo "Recognized environment variables:"
+            echo ""
+            echo "  CODE_DIRECTORIES:"
+            echo "    Filters the file to format based on the given whitespace"
+            echo "    separated directories listed."
+            echo "    Note that this is relative to the root of the project directory"
+            echo "  COMMIT_RANGE:"
+            echo "    The range of commits to check. By default this is HEAD~1..HEAD."
+            exit 0
+            ;;
+        -d|--directory)
+            echo "Adding directory to be verified: $2"
+            CODE_DIRECTORIES="${CODE_DIRECTORIES} $2"
+            shift 2
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+if [ -z "$COMMIT_RANGE" ] && [ -n "$CI_COMMIT_REF_NAME" ]
+then
+    # Gitlab unfortunately doesn't record base branches of commits when the PR
+    # comes from Github, so we need to detect branch names of PRs manually, and
+    # then reconstruct the correct range from that, by excluding all other
+    # branches.
+    case "$CI_COMMIT_REF_NAME" in
+        pr_[0-9]*)
+            EXCLUDE_LIST=$(mktemp)
+            EXCLUDE_LIST_REMOVE=$(mktemp)
+            git for-each-ref --format='%(refname)' | sort > $EXCLUDE_LIST
+            git for-each-ref --format='%(refname)' --points-at $CI_COMMIT_REF_NAME | sort > $EXCLUDE_LIST_REMOVE
+            TO_EXCLUDE="$(comm -23 $EXCLUDE_LIST $EXCLUDE_LIST_REMOVE | tr '\n' ' ')"
+            COMMIT_RANGE="$CI_COMMIT_REF_NAME --not $TO_EXCLUDE"
+            rm -f $EXCLUDE_LIST $EXCLUDE_LIST_REMOVE
+            ;;
+    esac
+fi
+
+if [ -z "$COMMIT_RANGE" ] && [ -n "$TRAVIS_BRANCH" ]
+then
+    COMMIT_RANGE="$TRAVIS_BRANCH..HEAD"
+fi
+
+if [ -z "$COMMIT_RANGE" ]
+then
+    # Just check previous commit if nothing else is specified.
+    COMMIT_RANGE=HEAD~1..HEAD
+fi
+
+if [ -n "$1" ]
+then
+    echo "Checking range: $*:"
+    git --no-pager log "$@"
+    commits="$(git rev-list --no-merges "$@")"
+else
+    echo "Checking range: ${COMMIT_RANGE}:"
+    git --no-pager log $COMMIT_RANGE
+    commits="$(git rev-list --no-merges $COMMIT_RANGE)"
+fi
+for commit in $commits
+do
+    COMMIT_MSG="$(git show -s --format=%B "$commit")"
+
+    echo >&2 "" # Give each commit some air
+
+    git checkout -q "$commit" || { echo >&2 "Fatal error! Failed to checkout the commit $commit"; exit 1 ;}
+
+    for dir in $CODE_DIRECTORIES; do
+        # Filter the Python files to check pending on the specified directory
+        COMMIT_PYTHON_FILES=$(git diff-tree --no-commit-id --name-only -r "$commit" -- "$dir*.py")
+        if [ -n "$COMMIT_PYTHON_FILES" ]; then
+            echo >&2 "Verifying that the Python code in $commit"
+            echo >&2 "and directory $dir is formatted correctly..."
+            for file in $COMMIT_PYTHON_FILES; do
+                if  ! black --check --verbose  "$file" >&2 ; then
+                    FAILED=True
+                    COMMIT_FAILED=True
+                    FAILED_FILES="$FAILED_FILES\n$file"
+                fi
+            done
+        fi
+        COMMIT_PYTHON_FILES=""
+    done
+    if [ -n $COMMIT_FAILED ]; then
+        echo >&2 "The Python code in commit $commit"
+        echo >&2 "is not formatted correctly, according to Black."
+        echo >&2 "Please format the code correctly, and commit anew."
+        echo >&2 ""
+        echo >&2 "Commit:"
+        echo >&2 "------------------------------------------------------------------------------"
+        echo >&2 "$COMMIT_MSG"
+        echo >&2 "------------------------------------------------------------------------------"
+        printf >&2 "Culprit(s): %b" "$FAILED_FILES"
+        echo >&2 ""
+        FAILED_FILES=
+        COMMIT_FAILED=
+    fi
+done
+
+if [ -n $FAILED ]; then
+    echo >&2 ""
+    echo >&2 "Please fix your code locally with: black <filename>."
+    echo >&2 "This will automatically format the code as needed."
+    echo >&2 "Then commit, and push as per usual"
+    echo >&2 "Note that the Black version used is: " "$BLACK_FORMATTER_VERSION."
+    exit 1
+fi


### PR DESCRIPTION
This commit adds a '.gitlab-ci-black-format-code.yml' file which can be included
into other projects' .gitlab-ci file, and which, when included, will check that
the Python3 code in the given directories are formatted according to Black's
preferences.

Changelog: Title

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>