### PR TITLE
Add templates for all common checks in golang repos

### DIFF
--- a/.gitlab-ci-check-apidocs.yml
+++ b/.gitlab-ci-check-apidocs.yml
@@ -1,0 +1,31 @@
+# .gitlab-ci-check-apidocs.yml
+#
+# This gitlab-ci template validates Swagger API specification assuming they
+# are in a docs/ folder
+#
+# Add it to the project in hand through Gitlab's include functionality
+#
+# include:
+#   - project: 'Northern.tech/Mender/mendertesting'
+#     file: '.gitlab-ci-check-apidocs.yml'
+#
+
+stages:
+  - test
+
+test:apidocs:
+  stage: test
+  image: node:latest
+  before_script:
+    # Install upstream Swagger verifier
+    - npm install -g swagger-cli
+    # Get our own Swagger verifier
+    - apt-get -qq update
+    - apt-get install -qy python3-pip
+    - pip3 install pyyaml
+    - wget https://raw.githubusercontent.com/mendersoftware/autodocs/master/verify_docs.py
+  script:
+    # Verify that the Swagger docs are valid
+    - swagger-cli validate docs/*.yml
+    # Verify that the Swagger docs follow the autodeployment requirements
+    - python3 verify_docs.py `find docs -name "*.yml"`

--- a/.gitlab-ci-check-golang-dockerimage.yml
+++ b/.gitlab-ci-check-golang-dockerimage.yml
@@ -1,0 +1,64 @@
+# .gitlab-ci-check-golang-dockerimage.yml
+#
+# This gitlab-ci template builds a Docker image assuming a single Dockerfile
+# and publish it on Docker Hub
+#
+# Add it to the project in hand through Gitlab's include functionality
+#
+# include:
+#   - project: 'Northern.tech/Mender/mendertesting'
+#     file: '.gitlab-ci-check-golang-dockerimage.yml'
+#
+# Requires the following variables set in the project CI/CD settings:
+# DOCKER_HUB_USERNAME: Username for docker.io
+# DOCKER_HUB_PASSWORD: Password for docker.io
+#
+
+stages:
+  - build
+  - publish
+
+build:
+  stage: build
+  tags:
+    - docker
+  image: docker
+  services:
+    - docker:dind
+  before_script:
+    - export DOCKER_REPOSITORY="mendersoftware/${CI_PROJECT_NAME}"
+    - export DOCKER_TAG=${CI_COMMIT_REF_SLUG:-master}
+    - export SERVICE_IMAGE=$DOCKER_REPOSITORY:$DOCKER_TAG
+    - export COMMIT_TAG="$CI_COMMIT_REF_SLUG"_"$CI_COMMIT_SHA"
+  script:
+    - echo "building ${CI_PROJECT_NAME} for ${SERVICE_IMAGE}"
+    - docker build -t $SERVICE_IMAGE .
+    - docker save $SERVICE_IMAGE > image.tar
+  artifacts:
+    expire_in: 2w
+    paths:
+      - image.tar
+
+publish:image:
+  stage: publish
+  only:
+    - /^(master|[0-9]+\.[0-9]+\.x)$/
+  tags:
+    - docker
+  image: docker
+  services:
+    - docker:dind
+  dependencies:
+    - build
+  before_script:
+    - export DOCKER_REPOSITORY="mendersoftware/${CI_PROJECT_NAME}"
+    - export DOCKER_TAG=${CI_COMMIT_REF_SLUG:-master}
+    - export SERVICE_IMAGE=$DOCKER_REPOSITORY:$DOCKER_TAG
+    - export COMMIT_TAG="$CI_COMMIT_REF_SLUG"_"$CI_COMMIT_SHA"
+  script:
+    - docker load -i image.tar
+    - docker tag $SERVICE_IMAGE $DOCKER_REPOSITORY:$COMMIT_TAG
+    - docker tag $SERVICE_IMAGE $DOCKER_REPOSITORY:$CI_COMMIT_REF_SLUG
+    - echo -n $DOCKER_HUB_PASSWORD | docker login -u $DOCKER_HUB_USERNAME --password-stdin
+    - docker push $DOCKER_REPOSITORY:$COMMIT_TAG
+    - docker push $SERVICE_IMAGE

--- a/.gitlab-ci-check-golang-static.yml
+++ b/.gitlab-ci-check-golang-static.yml
@@ -1,0 +1,36 @@
+# .gitlab-ci-check-golang-static.yml
+#
+# This gitlab-ci template performs the following static checks on Go code:
+# - check format with go fmt
+# - check code health with go vet
+# - check complexity with gocyclo
+#
+# Add it to the project in hand through Gitlab's include functionality
+#
+# include:
+#   - project: 'Northern.tech/Mender/mendertesting'
+#     file: '.gitlab-ci-check-golang-static.yml'
+#
+
+stages:
+  - test
+
+test:static:
+  stage: test
+  image: golang:1.13
+  before_script:
+    # Install cyclomatic dependency analysis tool
+    - go get -u github.com/fzipp/gocyclo
+    # Prepare GOPATH for the build
+    - mkdir -p /go/src/github.com/mendersoftware
+    - cp -r ${CI_PROJECT_DIR} /go/src/github.com/mendersoftware/${CI_PROJECT_NAME}
+    - cd /go/src/github.com/mendersoftware/${CI_PROJECT_NAME}
+  script:
+    # Test if code was formatted with 'go fmt'
+    # Command will format code and return modified files
+    # fail if any have been modified.
+    - if [ -n "$(go fmt)" ]; then echo 'Code is not formatted with "go fmt"'; false; fi
+    # Perform static code analysys
+    - go vet `go list ./... | grep -v vendor`
+    # Fail builds when the cyclomatic complexity reaches 20 or more
+    - gocyclo -over 20 `find . -iname '*.go' | grep -v 'vendor' | grep -v '_test.go'`

--- a/.gitlab-ci-check-golang-unittests.yml
+++ b/.gitlab-ci-check-golang-unittests.yml
@@ -1,0 +1,60 @@
+# .gitlab-ci-check-golang-unittests.yml
+#
+# This gitlab-ci template runs and publishes into codecov unit tests
+# from a Go repository
+#
+# Add it to the project in hand through Gitlab's include functionality
+#
+# include:
+#   - project: 'Northern.tech/Mender/mendertesting'
+#     file: '.gitlab-ci-check-golang-unittests.yml'
+#
+# Requires the following variables set in the project CI/CD settings:
+# CODECOV_TOKEN: Token from codecov.io for this repository
+#
+
+stages:
+  - test
+  - publish
+
+test:unit:
+  stage: test
+  image: golang:1.13
+  before_script:
+    # Install code coverage tooling
+    - go get -u github.com/axw/gocov/gocov
+    - go get -u golang.org/x/tools/cmd/cover
+
+    # Rename the branch we're on, so that it's not in the way for the
+    # subsequent fetch. It's ok if this fails, it just means we're not on any
+    # branch.
+    - git branch -m temp-branch || true
+    # Git trick: Fetch directly into our local branches instead of remote
+    # branches.
+    - git fetch origin 'refs/heads/*:refs/heads/*'
+    # Get last remaining tags, if any.
+    - git fetch --tags origin
+
+    # Prepare GOPATH for the build
+    - mkdir -p /go/src/github.com/mendersoftware
+    - cp -r ${CI_PROJECT_DIR} /go/src/github.com/mendersoftware/${CI_PROJECT_NAME}
+    - cd /go/src/github.com/mendersoftware/${CI_PROJECT_NAME}
+  script:
+    - go list ./... | grep -v vendor | xargs -n1 -I {} -P 4 go test -v -covermode=atomic -coverprofile=../../../{}/coverage.txt {} || exit $? ;
+    - mkdir -p tests/unit-coverage && find . -name 'coverage.txt' -exec cp --parents {} ./tests/unit-coverage \;
+    - tar -cvf ${CI_PROJECT_DIR}/unit-coverage.tar tests/unit-coverage
+  artifacts:
+    expire_in: 2w
+    paths:
+      - unit-coverage.tar
+
+publish:tests:
+  stage: publish
+  image: alpine
+  dependencies:
+    - test:unit
+  before_script:
+    - apk add --no-cache bash curl findutils git
+  script:
+    - tar -xvf unit-coverage.tar
+    - bash -c "bash <(curl -s https://codecov.io/bash) -Z -s ./tests/unit-coverage"


### PR DESCRIPTION
This commit adds the following templates:
* .gitlab-ci-check-golang-static.yml: Static checks like format, gocyclo
* .gitlab-ci-check-golang-unittests.yml: Run unit tests and publish
results into codecov
* .gitlab-ci-check-golang-dockerimage.yml: Build Docker image and
publish it into Docker Hub
* .gitlab-ci-check-apidocs.yml: Check Swagger formatted docs

They cover all common jobs for our Go repos.