### PR TITLE
Skip master execution of mendertesting commit checks

### DIFF
--- a/.gitlab-ci-check-commits-changelogs.yml
+++ b/.gitlab-ci-check-commits-changelogs.yml
@@ -3,8 +3,10 @@ stages:
   - test
 
 test:check-commits:
-  image: alpine
   stage: test
+  except:
+    - /^(master|[0-9]+\.[0-9]+\.x)$/
+  image: alpine
   before_script:
     # Install dependencies
     - apk add --no-cache git bash

--- a/.gitlab-ci-check-commits-signoffs.yml
+++ b/.gitlab-ci-check-commits-signoffs.yml
@@ -3,8 +3,10 @@ stages:
   - test
 
 test:check-commits:
-  image: alpine
   stage: test
+  except:
+    - /^(master|[0-9]+\.[0-9]+\.x)$/
+  image: alpine
   before_script:
     # Install dependencies
     - apk add --no-cache git bash

--- a/.gitlab-ci-check-commits.yml
+++ b/.gitlab-ci-check-commits.yml
@@ -3,8 +3,10 @@ stages:
   - test
 
 test:check-commits:
-  image: alpine
   stage: test
+  except:
+    - /^(master|[0-9]+\.[0-9]+\.x)$/
+  image: alpine
   before_script:
     # Install dependencies
     - apk add --no-cache git bash

--- a/.gitlab-ci-check-python3-format.yml
+++ b/.gitlab-ci-check-python3-format.yml
@@ -5,7 +5,7 @@
 # not formatted according to standard Black formatting rules.
 #
 # Add it to the project in hand through Gitlab's include functionality
-# 
+#
 # include:
 #   - project: 'Northern.tech/Mender/mendertesting'
 #     file: '.gitlab-ci-check-python3-format.yml'


### PR DESCRIPTION
This is mainly for mender-qa, where there vast majority of times we are
using "master" and wasting precious GitLab CI minutes with commit
checks. It won't hurt saving minutes on other repos neither.

Strictly speaking, we could apply the same principle to all templates,
but let's limit it only to the commit ones: as these are the really
superfluous ones in master while the others could possibly detect
errors in ninja merges.