### PR TITLE
Use --depth=1 when cloning git repositories in pipelines

### DIFF
--- a/.gitlab-ci-check-commits-changelogs.yml
+++ b/.gitlab-ci-check-commits-changelogs.yml
@@ -19,7 +19,7 @@ test:check-commits:
     - git fetch origin 'refs/heads/*:refs/heads/*'
     # Get last remaining tags, if any.
     - git fetch --tags origin
-    - git clone http://github.com/mendersoftware/mendertesting /tmp/mendertesting
+    - git clone --depth=1 http://github.com/mendersoftware/mendertesting /tmp/mendertesting
   script:
     # Verify that the commits have a changelog.
     - /tmp/mendertesting/check_commits.sh --changelogs

--- a/.gitlab-ci-check-commits-signoffs.yml
+++ b/.gitlab-ci-check-commits-signoffs.yml
@@ -19,7 +19,7 @@ test:check-commits:
     - git fetch origin 'refs/heads/*:refs/heads/*'
     # Get last remaining tags, if any.
     - git fetch --tags origin
-    - git clone http://github.com/mendersoftware/mendertesting /tmp/mendertesting
+    - git clone --depth=1 http://github.com/mendersoftware/mendertesting /tmp/mendertesting
   script:
     # Verify that the commits have signoffs.
     - /tmp/mendertesting/check_commits.sh --signoffs

--- a/.gitlab-ci-check-commits.yml
+++ b/.gitlab-ci-check-commits.yml
@@ -19,7 +19,7 @@ test:check-commits:
     - git fetch origin 'refs/heads/*:refs/heads/*'
     # Get last remaining tags, if any.
     - git fetch --tags origin
-    - git clone http://github.com/mendersoftware/mendertesting /tmp/mendertesting
+    - git clone --depth=1 http://github.com/mendersoftware/mendertesting /tmp/mendertesting
   script:
     # Check commit compliance.
     - /tmp/mendertesting/check_commits.sh

--- a/.gitlab-ci-check-golang-acceptance.yml
+++ b/.gitlab-ci-check-golang-acceptance.yml
@@ -86,7 +86,7 @@ test:acceptance_tests:
     - test:prepare_acceptance
   before_script:
     - apk add git bash
-    - git clone https://github.com/mendersoftware/integration.git
+    - git clone --depth=1 https://github.com/mendersoftware/integration.git
     - mv integration/extra/travis-testing/* tests/
     - mv docs/* tests/
     - mv ${CI_PROJECT_NAME} tests/

--- a/.gitlab-ci-check-license.yml
+++ b/.gitlab-ci-check-license.yml
@@ -17,7 +17,7 @@ test:check-license:
     - git fetch origin 'refs/heads/*:refs/heads/*'
     # Get last remaining tags, if any.
     - git fetch --tags origin
-    - git clone http://github.com/mendersoftware/mendertesting /tmp/mendertesting
+    - git clone --depth=1 http://github.com/mendersoftware/mendertesting /tmp/mendertesting
   script:
     # Check licenses
     - /tmp/mendertesting/check_license.sh

--- a/.gitlab-ci-check-python3-format.yml
+++ b/.gitlab-ci-check-python3-format.yml
@@ -67,7 +67,7 @@ test:check-python3-formatting:
     - git fetch origin 'refs/heads/*:refs/heads/*'
     # Get last remaining tags, if any.
     - git fetch --tags origin
-    - git clone --depth 1 http://github.com/mendersoftware/mendertesting /tmp/mendertesting
+    - git clone --depth=1 http://github.com/mendersoftware/mendertesting /tmp/mendertesting
   script:
     # Check that the Python code is correctly formatted
     - env /tmp/mendertesting/check_python_code_format


### PR DESCRIPTION
It is unnecessary to clone the whole history of the git repository,
a git shallow clone is enough.

Changelog: none
Signed-off-by: Fabio Tranchitella <fabio@tranchitella.eu>