### PR TITLE
QA-149: Use pipelines templates in all back-end repos

### DIFF
--- a/.gitlab-ci-check-docker-acceptance.yml
+++ b/.gitlab-ci-check-docker-acceptance.yml
@@ -32,8 +32,8 @@ test:prepare_acceptance:
     - docker:19.03.5-dind
   before_script:
     - export DOCKER_TAG=${CI_COMMIT_REF_SLUG:-master}
-    - export SERVICE_IMAGE="$DOCKER_REPOSITORY:$DOCKER_TAG"
-    - export COMMIT_TAG="$CI_COMMIT_REF_SLUG_$CI_COMMIT_SHA"
+    - export SERVICE_IMAGE=${DOCKER_REPOSITORY}:${DOCKER_TAG}
+    - export COMMIT_TAG=${CI_COMMIT_REF_SLUG}_${CI_COMMIT_SHA}
   script:
     - docker build -f Dockerfile.acceptance-testing -t $DOCKER_REPOSITORY:prtest .
     - docker save $DOCKER_REPOSITORY:prtest > tests_image.tar

--- a/.gitlab-ci-check-docker-acceptance.yml
+++ b/.gitlab-ci-check-docker-acceptance.yml
@@ -3,9 +3,11 @@
 # This gitlab-ci template builds, runs and publishes into codecov acceptance
 # tests from a Docker based repository.
 #
-# It assumes a tests/ folder with a Dockerfile for the Python test runner,
-# and a Dockerfile.acceptance-testing with the recipe to build the binary
-# with test coverage and serve the API.
+# It assumes the following files:
+# * Dockerfile.acceptance-testing: to build the the binary with test coverage.
+# * tests/Dockerfile to build the Python test runner.
+# * tests/docker-compose-acceptance.yml for the tests composition runtime.
+# * tests/docker-compose-acceptance-enterprise.yml (optional) for Enteprise tests.
 #
 # Requires DOCKER_REPOSITORY variable to be set in the calling Pipeline.
 # Add it to the project in hand through Gitlab's include functionality
@@ -18,6 +20,11 @@
 #
 # Requires the following variables set in the project CI/CD settings:
 #   CODECOV_TOKEN: Token from codecov.io for this repository
+#
+# If the tests require access to Mender Registry hosted images, it
+# will require also the following vabiables:
+#   REGISTRY_MENDER_IO_USERNAME: Username for registry.mender.io
+#   REGISTRY_MENDER_IO_PASSWORD: Password for registry.mender.io
 #
 
 stages:
@@ -63,10 +70,19 @@ test:acceptance_tests:
     - mv integration/extra/travis-testing/* tests/
     - mv docs/* tests/
     - mv ${CI_PROJECT_NAME} tests/
+    - if [ -f keys/private.pem ]; then
+        mv keys/private.pem tests/;
+      fi
     - docker load -i tests_image.tar
     - docker load -i acceptance_testing_image.tar
+    - if [ -n "$REGISTRY_MENDER_IO_USERNAME" ]; then
+        echo -n $REGISTRY_MENDER_IO_PASSWORD | docker login -u $REGISTRY_MENDER_IO_USERNAME --password-stdin registry.mender.io;
+      fi
   script:
-    - TESTS_DIR=$(pwd)/tests $(pwd)/tests/run-test-environment acceptance $(pwd)/integration $(pwd)/tests/docker-compose.yml
+    - TESTS_DIR=$(pwd)/tests $(pwd)/tests/run-test-environment acceptance $(pwd)/integration $(pwd)/tests/docker-compose-acceptance.yml
+    - if [ -f $(pwd)/tests/docker-compose-acceptance-enterprise.yml ]; then
+        TESTS_DIR=$(pwd)/tests $(pwd)/tests/run-test-environment acceptance $(pwd)/integration $(pwd)/tests/docker-compose-acceptance-enterprise.yml;
+      fi
   artifacts:
     expire_in: 2w
     paths:

--- a/.gitlab-ci-check-docker-acceptance.yml
+++ b/.gitlab-ci-check-docker-acceptance.yml
@@ -48,12 +48,15 @@ test:prepare_acceptance:
     - docker run --rm --entrypoint "/bin/sh" -v $(pwd):/binary $DOCKER_REPOSITORY:pr -c "cp /usr/bin/${CI_PROJECT_NAME} /binary"
     - docker build -t testing -f tests/Dockerfile tests
     - docker save testing > acceptance_testing_image.tar
+    - wget https://d1b0l86ne08fsf.cloudfront.net/mender-artifact/master/mender-artifact
+    - chmod +x mender-artifact
   artifacts:
     expire_in: 2w
     paths:
       - tests_image.tar
       - acceptance_testing_image.tar
       - ${CI_PROJECT_NAME}
+      - mender-artifact
 
 test:acceptance_tests:
   stage: test
@@ -70,6 +73,7 @@ test:acceptance_tests:
     - mv mender-integration/extra/travis-testing/* tests/
     - mv docs/* tests/
     - mv ${CI_PROJECT_NAME} tests/
+    - mv mender-artifact tests/
     - if [ -f keys/private.pem ]; then
         mv keys/private.pem tests/;
       fi

--- a/.gitlab-ci-check-docker-acceptance.yml
+++ b/.gitlab-ci-check-docker-acceptance.yml
@@ -66,8 +66,8 @@ test:acceptance_tests:
     - test:prepare_acceptance
   before_script:
     - apk add git bash
-    - git clone --depth=1 https://github.com/mendersoftware/integration.git
-    - mv integration/extra/travis-testing/* tests/
+    - git clone --depth=1 https://github.com/mendersoftware/integration.git mender-integration
+    - mv mender-integration/extra/travis-testing/* tests/
     - mv docs/* tests/
     - mv ${CI_PROJECT_NAME} tests/
     - if [ -f keys/private.pem ]; then
@@ -79,9 +79,9 @@ test:acceptance_tests:
         echo -n $REGISTRY_MENDER_IO_PASSWORD | docker login -u $REGISTRY_MENDER_IO_USERNAME --password-stdin registry.mender.io;
       fi
   script:
-    - TESTS_DIR=$(pwd)/tests $(pwd)/tests/run-test-environment acceptance $(pwd)/integration $(pwd)/tests/docker-compose-acceptance.yml
+    - TESTS_DIR=$(pwd)/tests $(pwd)/tests/run-test-environment acceptance $(pwd)/mender-integration $(pwd)/tests/docker-compose-acceptance.yml
     - if [ -f $(pwd)/tests/docker-compose-acceptance-enterprise.yml ]; then
-        TESTS_DIR=$(pwd)/tests $(pwd)/tests/run-test-environment acceptance $(pwd)/integration $(pwd)/tests/docker-compose-acceptance-enterprise.yml;
+        TESTS_DIR=$(pwd)/tests $(pwd)/tests/run-test-environment acceptance $(pwd)/mender-integration $(pwd)/tests/docker-compose-acceptance-enterprise.yml;
       fi
   artifacts:
     expire_in: 2w

--- a/.gitlab-ci-check-docker-acceptance.yml
+++ b/.gitlab-ci-check-docker-acceptance.yml
@@ -7,14 +7,17 @@
 # and a Dockerfile.acceptance-testing with the recipe to build the binary
 # with test coverage and serve the API.
 #
+# Requires DOCKER_REPOSITORY variable to be set in the calling Pipeline.
 # Add it to the project in hand through Gitlab's include functionality
 #
+# variables:
+#   DOCKER_REPOSITORY: <Image FQN, i.e mendersoftware/reponame>
 # include:
 #   - project: 'Northern.tech/Mender/mendertesting'
 #     file: '.gitlab-ci-check-docker-acceptance.yml'
 #
 # Requires the following variables set in the project CI/CD settings:
-# CODECOV_TOKEN: Token from codecov.io for this repository
+#   CODECOV_TOKEN: Token from codecov.io for this repository
 #
 
 stages:
@@ -28,7 +31,6 @@ test:prepare_acceptance:
   services:
     - docker:19.03.5-dind
   before_script:
-    - export DOCKER_REPOSITORY="mendersoftware/${CI_PROJECT_NAME}"
     - export DOCKER_TAG=${CI_COMMIT_REF_SLUG:-master}
     - export SERVICE_IMAGE="$DOCKER_REPOSITORY:$DOCKER_TAG"
     - export COMMIT_TAG="$CI_COMMIT_REF_SLUG_$CI_COMMIT_SHA"

--- a/.gitlab-ci-check-docker-acceptance.yml
+++ b/.gitlab-ci-check-docker-acceptance.yml
@@ -1,7 +1,7 @@
-# .gitlab-ci-check-golang-acceptance.yml
+# .gitlab-ci-check-docker-acceptance.yml
 #
 # This gitlab-ci template builds, runs and publishes into codecov acceptance
-# tests from a Go repository.
+# tests from a Docker based repository.
 #
 # It assumes a tests/ folder with a Dockerfile for the Python test runner,
 # and a Dockerfile.acceptance-testing with the recipe to build the binary
@@ -11,7 +11,7 @@
 #
 # include:
 #   - project: 'Northern.tech/Mender/mendertesting'
-#     file: '.gitlab-ci-check-golang-acceptance.yml'
+#     file: '.gitlab-ci-check-docker-acceptance.yml'
 #
 # Requires the following variables set in the project CI/CD settings:
 # CODECOV_TOKEN: Token from codecov.io for this repository
@@ -39,11 +39,6 @@ test:prepare_acceptance:
     - docker run --rm --entrypoint "/bin/sh" -v $(pwd):/binary $DOCKER_REPOSITORY:pr -c "cp /usr/bin/${CI_PROJECT_NAME} /binary"
     - docker build -t testing -f tests/Dockerfile tests
     - docker save testing > acceptance_testing_image.tar
-  cache:
-    key: "$CI_COMMIT_REF_SLUG"
-    paths:
-      - /go/src/github.com/mendersoftware/${CI_PROJECT_NAME}/${CI_PROJECT_NAME}-test
-    policy: pull
   artifacts:
     expire_in: 2w
     paths:

--- a/.gitlab-ci-check-docker-build.yml
+++ b/.gitlab-ci-check-docker-build.yml
@@ -1,4 +1,4 @@
-# .gitlab-ci-check-golang-dockerimage.yml
+# .gitlab-ci-check-docker-build.yml
 #
 # This gitlab-ci template builds a Docker image assuming a single Dockerfile
 # and publish it on Docker Hub
@@ -9,7 +9,7 @@
 #
 # include:
 #   - project: 'Northern.tech/Mender/mendertesting'
-#     file: '.gitlab-ci-check-golang-dockerimage.yml'
+#     file: '.gitlab-ci-check-docker-build.yml'
 #
 # Requires the following variables set in the project CI/CD settings:
 # DOCKER_HUB_USERNAME: Username for docker.io

--- a/.gitlab-ci-check-docker-build.yml
+++ b/.gitlab-ci-check-docker-build.yml
@@ -36,8 +36,8 @@ build:
     - docker:19.03.5-dind
   before_script:
     - export DOCKER_TAG=${CI_COMMIT_REF_SLUG:-master}
-    - export SERVICE_IMAGE="$DOCKER_REPOSITORY:$DOCKER_TAG"
-    - export COMMIT_TAG="$CI_COMMIT_REF_SLUG_$CI_COMMIT_SHA"
+    - export SERVICE_IMAGE=${DOCKER_REPOSITORY}:${DOCKER_TAG}
+    - export COMMIT_TAG=${CI_COMMIT_REF_SLUG}_${CI_COMMIT_SHA}
   script:
     - echo "building ${CI_PROJECT_NAME} for ${SERVICE_IMAGE}"
     - docker build -t $SERVICE_IMAGE .
@@ -60,8 +60,8 @@ publish:image:
     - build
   before_script:
     - export DOCKER_TAG=${CI_COMMIT_REF_SLUG:-master}
-    - export SERVICE_IMAGE="$DOCKER_REPOSITORY:$DOCKER_TAG"
-    - export COMMIT_TAG="$CI_COMMIT_REF_SLUG_$CI_COMMIT_SHA"
+    - export SERVICE_IMAGE=${DOCKER_REPOSITORY}:${DOCKER_TAG}
+    - export COMMIT_TAG=${CI_COMMIT_REF_SLUG}_${CI_COMMIT_SHA}
   script:
     - docker load -i image.tar
     - docker tag $SERVICE_IMAGE $DOCKER_REPOSITORY:$COMMIT_TAG

--- a/.gitlab-ci-check-docker-build.yml
+++ b/.gitlab-ci-check-docker-build.yml
@@ -1,19 +1,26 @@
 # .gitlab-ci-check-docker-build.yml
 #
-# This gitlab-ci template builds a Docker image assuming a single Dockerfile
-# and publish it on Docker Hub
+# This gitlab-ci template builds a Docker image and publishes it
+# on Docker Hub or Mender Registry
 #
 # It assumes a Dockerfile in the root of the repository.
 #
+# Requires DOCKER_REPOSITORY variable to be set in the calling Pipeline.
 # Add it to the project in hand through Gitlab's include functionality
 #
+# variables:
+#   DOCKER_REPOSITORY: <Image FQN, i.e mendersoftware/reponame>
 # include:
 #   - project: 'Northern.tech/Mender/mendertesting'
 #     file: '.gitlab-ci-check-docker-build.yml'
 #
-# Requires the following variables set in the project CI/CD settings:
-# DOCKER_HUB_USERNAME: Username for docker.io
-# DOCKER_HUB_PASSWORD: Password for docker.io
+# Requires credentials for the registry where to push the image.
+# Set in the project CI/CD settings either Docker Hub credentials:
+#   DOCKER_HUB_USERNAME: Username for docker.io
+#   DOCKER_HUB_PASSWORD: Password for docker.io
+# or Mender Registry ones:
+#   REGISTRY_MENDER_IO_USERNAME: Username for registry.mender.io
+#   REGISTRY_MENDER_IO_PASSWORD: Password for registry.mender.io
 #
 
 stages:
@@ -28,7 +35,6 @@ build:
   services:
     - docker:19.03.5-dind
   before_script:
-    - export DOCKER_REPOSITORY="mendersoftware/${CI_PROJECT_NAME}"
     - export DOCKER_TAG=${CI_COMMIT_REF_SLUG:-master}
     - export SERVICE_IMAGE="$DOCKER_REPOSITORY:$DOCKER_TAG"
     - export COMMIT_TAG="$CI_COMMIT_REF_SLUG_$CI_COMMIT_SHA"
@@ -53,7 +59,6 @@ publish:image:
   dependencies:
     - build
   before_script:
-    - export DOCKER_REPOSITORY="mendersoftware/${CI_PROJECT_NAME}"
     - export DOCKER_TAG=${CI_COMMIT_REF_SLUG:-master}
     - export SERVICE_IMAGE="$DOCKER_REPOSITORY:$DOCKER_TAG"
     - export COMMIT_TAG="$CI_COMMIT_REF_SLUG_$CI_COMMIT_SHA"
@@ -61,6 +66,10 @@ publish:image:
     - docker load -i image.tar
     - docker tag $SERVICE_IMAGE $DOCKER_REPOSITORY:$COMMIT_TAG
     - docker tag $SERVICE_IMAGE $DOCKER_REPOSITORY:$CI_COMMIT_REF_SLUG
-    - echo -n $DOCKER_HUB_PASSWORD | docker login -u $DOCKER_HUB_USERNAME --password-stdin
+    - if [ -n "$REGISTRY_MENDER_IO_USERNAME" ]; then
+        echo -n $REGISTRY_MENDER_IO_PASSWORD | docker login -u $REGISTRY_MENDER_IO_USERNAME --password-stdin registry.mender.io;
+      else
+        echo -n $DOCKER_HUB_PASSWORD | docker login -u $DOCKER_HUB_USERNAME --password-stdin;
+      fi
     - docker push $DOCKER_REPOSITORY:$COMMIT_TAG
     - docker push $SERVICE_IMAGE

--- a/.gitlab-ci-check-golang-acceptance.yml
+++ b/.gitlab-ci-check-golang-acceptance.yml
@@ -4,7 +4,8 @@
 # tests from a Go repository.
 #
 # It assumes a tests/ folder with a Dockerfile for the Python test runner,
-# and a Dockerfile.acceptance-testing for the Go test binary.
+# and a Dockerfile.acceptance-testing with the recipe to build the binary
+# with test coverage and serve the API.
 #
 # Add it to the project in hand through Gitlab's include functionality
 #
@@ -12,44 +13,20 @@
 #   - project: 'Northern.tech/Mender/mendertesting'
 #     file: '.gitlab-ci-check-golang-acceptance.yml'
 #
-# The template uses latest Mender supported golang version.
-# To override the version to use, append to your .gitlab-ci.yml:
-# test:build_acceptance:
-#   image: golang:1.11
-#
 # Requires the following variables set in the project CI/CD settings:
 # CODECOV_TOKEN: Token from codecov.io for this repository
 #
 
 stages:
-  - test_prep_build
   - test_prep
   - test
   - publish
-
-test:build_acceptance:
-  stage: test_prep_build
-  image: golang:1.13
-  before_script:
-    # Prepare GOPATH for the build
-    - mkdir -p /go/src/github.com/mendersoftware
-    - cp -r ${CI_PROJECT_DIR} /go/src/github.com/mendersoftware/${CI_PROJECT_NAME}
-    - cd /go/src/github.com/mendersoftware/${CI_PROJECT_NAME}
-  script:
-    - CGO_ENABLED=0 go test -c -o ${CI_PROJECT_NAME}-test -coverpkg $(go list ./... | grep -v vendor | grep -v mock | grep -v test | tr  '\n' ,)
-    - cp ${CI_PROJECT_NAME}-test ${CI_PROJECT_DIR}
-  artifacts:
-    untracked: true
-    paths:
-      - ${CI_PROJECT_NAME}-test
 
 test:prepare_acceptance:
   stage: test_prep
   image: docker
   services:
     - docker:19.03.5-dind
-  dependencies:
-    - test:build_acceptance
   before_script:
     - export DOCKER_REPOSITORY="mendersoftware/${CI_PROJECT_NAME}"
     - export DOCKER_TAG=${CI_COMMIT_REF_SLUG:-master}
@@ -82,7 +59,6 @@ test:acceptance_tests:
   services:
     - docker:19.03.5-dind
   dependencies:
-    - test:build_acceptance
     - test:prepare_acceptance
   before_script:
     - apk add git bash

--- a/.gitlab-ci-check-golang-static.yml
+++ b/.gitlab-ci-check-golang-static.yml
@@ -11,6 +11,9 @@
 #   - project: 'Northern.tech/Mender/mendertesting'
 #     file: '.gitlab-ci-check-golang-static.yml'
 #
+# If the repo has some compile time dependencies, the template expect to
+# exist a deb-requirements.txt file with the Debian OS required packages
+#
 
 stages:
   - test
@@ -21,6 +24,11 @@ test:static:
   before_script:
     # Install cyclomatic dependency analysis tool
     - go get -u github.com/fzipp/gocyclo
+    # Install compile dependencies
+    - if [ -f deb-requirements.txt ]; then
+        apt-get -qq update &&
+        apt install -yq $(cat deb-requirements.txt);
+      fi
     # Prepare GOPATH for the build
     - mkdir -p /go/src/github.com/mendersoftware
     - cp -r ${CI_PROJECT_DIR} /go/src/github.com/mendersoftware/${CI_PROJECT_NAME}

--- a/.gitlab-ci-check-golang-unittests.yml
+++ b/.gitlab-ci-check-golang-unittests.yml
@@ -14,7 +14,7 @@
 #   image: golang:1.11.4
 #
 # Requires the following variables set in the project CI/CD settings:
-# CODECOV_TOKEN: Token from codecov.io for this repository
+#   CODECOV_TOKEN: Token from codecov.io for this repository
 #
 
 stages:

--- a/.gitlab-ci-check-golang-unittests.yml
+++ b/.gitlab-ci-check-golang-unittests.yml
@@ -9,6 +9,9 @@
 #   - project: 'Northern.tech/Mender/mendertesting'
 #     file: '.gitlab-ci-check-golang-unittests.yml'
 #
+# If the repo has some compile time dependencies, the template expect to
+# exist a deb-requirements.txt file with the Debian OS required packages
+#
 # The template uses latest Mender supported golang version.
 # To override the version to use, append to your .gitlab-ci.yml:
 #   image: golang:1.11.4
@@ -36,6 +39,11 @@ test:unit:
     - echo "deb http://repo.mongodb.org/apt/debian stretch/mongodb-org/3.6 main" | tee /etc/apt/sources.list.d/mongodb-org-3.6.list
     - apt-get -qq update
     - apt-get install -qy --allow-unauthenticated mongodb-org-server=3.6.11
+
+    # Install compile dependencies
+    - if [ -f deb-requirements.txt ]; then
+        apt install -yq $(cat deb-requirements.txt);
+      fi
 
     # Rename the branch we're on, so that it's not in the way for the
     # subsequent fetch. It's ok if this fails, it just means we're not on any


### PR DESCRIPTION
This PR collects a set of changes and extensions for the templates to work with all repositories. It also has as important bugfix!

Best review commit by commit, I think.

Important: two templates have been renamed. Fortunately, only one repo is using them (inventory) so I will coordinate the merges to not affect ongoing PRs.

This PR will then unblock the following PRs:
* https://github.com/mendersoftware/deviceauth/pull/310
* https://github.com/mendersoftware/tenantadm/pull/121
* https://github.com/mendersoftware/inventory/pull/153
* https://github.com/mendersoftware/deployments/pull/393
* https://github.com/mendersoftware/useradm/pull/151