### PR TITLE
Set GIT_DEPTH variable to templates doing commit checks

### DIFF
--- a/.gitlab-ci-check-commits-changelogs.yml
+++ b/.gitlab-ci-check-commits-changelogs.yml
@@ -7,6 +7,8 @@ test:check-commits:
   except:
     - /^(master|[0-9]+\.[0-9]+\.x)$/
   image: alpine
+  variables:
+    GIT_DEPTH: 0
   before_script:
     # Install dependencies
     - apk add --no-cache git bash

--- a/.gitlab-ci-check-commits-signoffs.yml
+++ b/.gitlab-ci-check-commits-signoffs.yml
@@ -7,6 +7,8 @@ test:check-commits:
   except:
     - /^(master|[0-9]+\.[0-9]+\.x)$/
   image: alpine
+  variables:
+    GIT_DEPTH: 0
   before_script:
     # Install dependencies
     - apk add --no-cache git bash

--- a/.gitlab-ci-check-commits.yml
+++ b/.gitlab-ci-check-commits.yml
@@ -7,6 +7,8 @@ test:check-commits:
   except:
     - /^(master|[0-9]+\.[0-9]+\.x)$/
   image: alpine
+  variables:
+    GIT_DEPTH: 0
   before_script:
     # Install dependencies
     - apk add --no-cache git bash

--- a/.gitlab-ci-check-golang-unittests.yml
+++ b/.gitlab-ci-check-golang-unittests.yml
@@ -29,6 +29,8 @@ test:unit:
   image: golang:1.13
   services:
     - mongo
+  variables:
+    GIT_DEPTH: 0
   before_script:
     # Install code coverage tooling
     - go get -u github.com/axw/gocov/gocov


### PR DESCRIPTION
We experienced gitlab pipeline failures due to shallow clones of the git
repository. We set the GIT_DEPTH variable to 0 to explicitly instruct
the GitLab Runners to perform a full clone.

See original commit in deployments-enterprise repo:
https://github.com/mendersoftware/deployments-enterprise/commit/989a6915fc44764ec6ef36df517cb12ea760d7f5