### PR TITLE
MEN-3344: Extend Docker template to publish staging images

### DIFF
--- a/.gitlab-ci-check-docker-build.yml
+++ b/.gitlab-ci-check-docker-build.yml
@@ -57,7 +57,7 @@ build:docker:
 publish:image:
   stage: publish
   only:
-    - /^(master|[0-9]+\.[0-9]+\.x)$/
+    - /^(master|staging|[0-9]+\.[0-9]+\.x)$/
   tags:
     - docker
   image: docker


### PR DESCRIPTION
Any repo with staging branch, will now publish into its own registry
images with tags staging_<git-sha>