### PR TITLE
Templates Docker publish related fixes

### DIFF
--- a/.gitlab-ci-check-docker-acceptance.yml
+++ b/.gitlab-ci-check-docker-acceptance.yml
@@ -80,7 +80,7 @@ test:acceptance_tests:
     - docker load -i tests_image.tar
     - docker load -i acceptance_testing_image.tar
     - if [ -n "$REGISTRY_MENDER_IO_USERNAME" ]; then
-        echo -n $REGISTRY_MENDER_IO_PASSWORD | docker login -u $REGISTRY_MENDER_IO_USERNAME --password-stdin registry.mender.io;
+        docker login -u $REGISTRY_MENDER_IO_USERNAME -p $REGISTRY_MENDER_IO_PASSWORD registry.mender.io;
       fi
   script:
     - TESTS_DIR=$(pwd)/tests $(pwd)/tests/run-test-environment acceptance $(pwd)/mender-integration $(pwd)/tests/docker-compose-acceptance.yml

--- a/.gitlab-ci-check-docker-build.yml
+++ b/.gitlab-ci-check-docker-build.yml
@@ -73,10 +73,7 @@ publish:image:
     - docker load -i image.tar
     - docker tag $SERVICE_IMAGE $DOCKER_REPOSITORY:$COMMIT_TAG
     - docker tag $SERVICE_IMAGE $DOCKER_REPOSITORY:$CI_COMMIT_REF_SLUG
-    - if [ -n "$REGISTRY_MENDER_IO_USERNAME" ]; then
-        docker login -u $REGISTRY_MENDER_IO_USERNAME -p $REGISTRY_MENDER_IO_PASSWORD registry.mender.io;
-      else
-        docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD;
-      fi
+    - docker login -u $REGISTRY_MENDER_IO_USERNAME -p $REGISTRY_MENDER_IO_PASSWORD registry.mender.io
+    - docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
     - docker push $DOCKER_REPOSITORY:$COMMIT_TAG
     - docker push $SERVICE_IMAGE

--- a/.gitlab-ci-check-docker-build.yml
+++ b/.gitlab-ci-check-docker-build.yml
@@ -74,9 +74,9 @@ publish:image:
     - docker tag $SERVICE_IMAGE $DOCKER_REPOSITORY:$COMMIT_TAG
     - docker tag $SERVICE_IMAGE $DOCKER_REPOSITORY:$CI_COMMIT_REF_SLUG
     - if [ -n "$REGISTRY_MENDER_IO_USERNAME" ]; then
-        echo -n $REGISTRY_MENDER_IO_PASSWORD | docker login -u $REGISTRY_MENDER_IO_USERNAME --password-stdin registry.mender.io;
+        docker login -u $REGISTRY_MENDER_IO_USERNAME -p $REGISTRY_MENDER_IO_PASSWORD registry.mender.io;
       else
-        echo -n $DOCKER_HUB_PASSWORD | docker login -u $DOCKER_HUB_USERNAME --password-stdin;
+        docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD;
       fi
     - docker push $DOCKER_REPOSITORY:$COMMIT_TAG
     - docker push $SERVICE_IMAGE

--- a/.gitlab-ci-check-docker-build.yml
+++ b/.gitlab-ci-check-docker-build.yml
@@ -54,10 +54,12 @@ build:docker:
     paths:
       - image.tar
 
-publish:image:
+# Internal template
+.publish_image:
   stage: publish
   only:
-    - /^(master|staging|[0-9]+\.[0-9]+\.x)$/
+    refs:
+      - /^(master|staging|[0-9]+\.[0-9]+\.x)$/
   tags:
     - docker
   image: docker
@@ -76,4 +78,22 @@ publish:image:
     - docker login -u $REGISTRY_MENDER_IO_USERNAME -p $REGISTRY_MENDER_IO_PASSWORD registry.mender.io
     - docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
     - docker push $DOCKER_REPOSITORY:$COMMIT_TAG
-    - docker push $SERVICE_IMAGE
+    - docker push $DOCKER_REPOSITORY:$CI_COMMIT_REF_SLUG
+
+# Regular job, publish into user's DOCKER_REPOSITORY
+publish:image:
+  extends: .publish_image
+
+# Extra job for Enterprise repos, publish also to Docker Hub
+publish:image:dockerhub:
+  extends: .publish_image
+  only:
+    variables:
+      - $DOCKER_REPOSITORY =~ /^registry\.mender\.io.\/*/
+  before_script:
+    # The trick here is to let SERVICE_NAME use the origianl DOCKER_REPOSITORY (i.e. registry.mender.io)
+    # while overriding it at the end for Docker Hub, so that the tag/push in script is done for the latter.
+    - export DOCKER_TAG=${CI_COMMIT_REF_SLUG:-master}
+    - export SERVICE_IMAGE=${DOCKER_REPOSITORY}:${DOCKER_TAG}
+    - export COMMIT_TAG=${CI_COMMIT_REF_SLUG}_${CI_COMMIT_SHA}
+    - export DOCKER_REPOSITORY=${DOCKER_REPOSITORY#registry.mender.io/}


### PR DESCRIPTION
- [templates] Take password from CLI on docker login calls
The --password-stdin option is throwing errors in some GitLab shared
runners. The password will be masked anyway, so it is safe.

- [docker-build-template] Log in in both registries inconditionally
Now all repos have both credentials anyway (inheriged from the group) so
just log in in both.

- [docker-build-template] Publish Enterprise images to Docker Hub
Add an extra job for Enterprise repo (i.e. when the caller has
registry.mender.io in DOCKER_REPOSITORY) to publish the image with the
same tags into Docker Hub.
