### PR TITLE
[docker-build-template] Fix DOCKERDIR/DOCKERFILE usage

### DIFF
--- a/.gitlab-ci-check-docker-build.yml
+++ b/.gitlab-ci-check-docker-build.yml
@@ -50,7 +50,7 @@ build:docker:
     - echo "building ${CI_PROJECT_NAME} for ${SERVICE_IMAGE}"
     - docker build
         --tag $SERVICE_IMAGE
-        --file ${DOCKERFILE:-Dockerfile}
+        --file ${DOCKER_DIR:-.}/${DOCKERFILE:-Dockerfile}
         --build-arg GIT_COMMIT_TAG="${COMMIT_TAG}"
         ${DOCKER_DIR:-.}
     - docker save $SERVICE_IMAGE > image.tar


### PR DESCRIPTION
For repos using a different DOCKERDIR, the DOCKERFILE needs to be
adjusted accordingly.

Fixes commit 0745070.