### PR TITLE
[github status] Do not run for master and other protected branches

### DIFF
--- a/.gitlab-ci-check-commits-changelogs.yml
+++ b/.gitlab-ci-check-commits-changelogs.yml
@@ -5,7 +5,7 @@ stages:
 test:check-commits:
   stage: test
   except:
-    - /^(master|[0-9]+\.[0-9]+\.x)$/
+    - /^(master|staging|[0-9]+\.[0-9]+\.x)$/
   image: alpine
   variables:
     GIT_DEPTH: 0

--- a/.gitlab-ci-check-commits-signoffs.yml
+++ b/.gitlab-ci-check-commits-signoffs.yml
@@ -5,7 +5,7 @@ stages:
 test:check-commits:
   stage: test
   except:
-    - /^(master|[0-9]+\.[0-9]+\.x)$/
+    - /^(master|staging|[0-9]+\.[0-9]+\.x)$/
   image: alpine
   variables:
     GIT_DEPTH: 0

--- a/.gitlab-ci-check-commits.yml
+++ b/.gitlab-ci-check-commits.yml
@@ -5,7 +5,7 @@ stages:
 test:check-commits:
   stage: test
   except:
-    - /^(master|[0-9]+\.[0-9]+\.x)$/
+    - /^(master|staging|[0-9]+\.[0-9]+\.x)$/
   image: alpine
   variables:
     GIT_DEPTH: 0

--- a/.gitlab-ci-github-status-updates.yml
+++ b/.gitlab-ci-github-status-updates.yml
@@ -13,6 +13,8 @@ stages:
 
 github:start:
   stage: .pre
+  except:
+    - /^(master|staging|[0-9]+\.[0-9]+\.x)$/
   # Keep overhead low by using a small image with curl preinstalled.
   image: appropriate/curl
   script:
@@ -21,6 +23,8 @@ github:start:
 
 github:success:
   stage: .post
+  except:
+    - /^(master|staging|[0-9]+\.[0-9]+\.x)$/
   when: on_success
   # Keep overhead low by using a small image with curl preinstalled.
   image: appropriate/curl
@@ -30,6 +34,8 @@ github:success:
 
 github:failure:
   stage: .post
+  except:
+    - /^(master|staging|[0-9]+\.[0-9]+\.x)$/
   when: on_failure
   # Keep overhead low by using a small image with curl preinstalled.
   image: appropriate/curl


### PR DESCRIPTION
- [github status] Do not run for master and other protected branches
The motivation for this change is to skip them for mender-qa master,
which would report to non existing PR (master) when running integration
pipeline in behalf of a PR in any other repo.

- [commit checks] Add staging to the list of branches to skip
Just to keep it aligned with our current "protected branches".
