### PR TITLE
[docker-build-template] Extend new versioning to master images

### DIFF
--- a/.gitlab-ci-check-docker-build.yml
+++ b/.gitlab-ci-check-docker-build.yml
@@ -63,7 +63,7 @@ publish:image:
   stage: publish
   only:
     refs:
-      # NOTE: We can remove [0-9]+\.[0-9]+\.x from here after 2.3.x goes EOL
+      # NOTE: We can remove master and [0-9]+\.[0-9]+\.x from here after 2.3.x goes EOL
       - /^(master|staging|[0-9]+\.[0-9]+\.x)$/
   tags:
     - docker
@@ -99,11 +99,11 @@ publish:image:dockerhub:
     - export COMMIT_TAG=${CI_COMMIT_REF_SLUG}_${CI_COMMIT_SHA}
     - export DOCKER_REPOSITORY=${DOCKER_REPOSITORY#registry.mender.io/}
 
-publish:image:release:
+publish:image:mender:
   stage: publish
   only:
     refs:
-      - /^[0-9]+\.[0-9]+\.x$/
+      - /^(master|[0-9]+\.[0-9]+\.x)$/
   tags:
     - docker
   image: docker
@@ -136,8 +136,8 @@ publish:image:release:
     - done
 
 # Extra job for Enterprise repos, publish also to Docker Hub
-publish:image:release:dockerhub:
-  extends: publish:image:release
+publish:image:mender:dockerhub:
+  extends: publish:image:mender
   only:
     variables:
       - $DOCKER_REPOSITORY =~ /^registry\.mender\.io.\/*/


### PR DESCRIPTION
So that :mender-master and :mender-master type of tags are also
published into the container registries.