### PR TITLE
Fix error assertion when check_license.sh fails

### DIFF
--- a/licenses.go
+++ b/licenses.go
@@ -48,7 +48,11 @@ func SetFirstEnterpriseCommit(sha string) {
 func CheckMenderCompliance(t *testing.T) {
 	t.Run("Checking Mender compliance", func(t *testing.T) {
 		err := checkMenderCompliance()
-		assert.NoError(t, err, err)
+		msg := ""
+		if err != nil {
+			msg = err.Error()
+		}
+		assert.NoError(t, err, msg)
 	})
 }
 


### PR DESCRIPTION
When one of the licenses did not match, there was an error:

`panic: interface conversion: interface {} is *mendertesting.MenderComplianceError, not string`

ChangeLog:none
Signed-off-by: Peter Grzybowski <peter@northern.tech>