### PR TITLE
[docker-build-template] Skip publish:image:mender for not found repos

### DIFF
--- a/.gitlab-ci-check-docker-build.yml
+++ b/.gitlab-ci-check-docker-build.yml
@@ -122,10 +122,15 @@ publish:image:mender:
     # Get release_tool:
     - git clone https://github.com/mendersoftware/integration.git mender-integration
     - alias release_tool=$(realpath mender-integration/extra/release_tool.py)
-    # If the repo is not part of a Mender release, ignore
+    # If the repo is not recognized, ignore
+    - if ! echo $(release_tool --list git --all) | grep $CI_PROJECT_NAME; then
+    -  echo "Repository $CI_PROJECT_NAME not found in release_tool. Exiting"
+    -  exit 0
+    - fi
+    # If the repo/branch is not part of a Mender release, also ignore
     - integration_versions=$(release_tool --integration-versions-including $CI_PROJECT_NAME --version $CI_COMMIT_REF_SLUG | sed -e 's/origin\///')
     - if test -z "$integration_versions"; then
-    -  echo "Repository $CI_PROJECT_NAME version $CI_COMMIT_REF_SLUG is not part of any Mender release"
+    -  echo "Repository $CI_PROJECT_NAME version $CI_COMMIT_REF_SLUG is not part of any Mender release. Exiting"
     -  exit 0
     - fi
     # Load image and logins


### PR DESCRIPTION
Yet another case where we need to skip the publish is when the repo is
not found at all.