### PR TITLE
fix: Remove the err message from the NoErr assertion 

### DIFF
--- a/licenses.go
+++ b/licenses.go
@@ -48,7 +48,7 @@ func SetFirstEnterpriseCommit(sha string) {
 func CheckMenderCompliance(t *testing.T) {
 	t.Run("Checking Mender compliance", func(t *testing.T) {
 		err := checkMenderCompliance()
-		assert.NoError(t, err, err)
+		assert.NoError(t, err)
 	})
 }
 


### PR DESCRIPTION
The error is already printed as the Error message. Also the err as the message
panics on older versions of testify.

Changelog: None

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>