### PR TITLE
golang-tests: prevented go mod tracking of test dependencies

### DIFF
--- a/.gitlab-ci-check-golang-static.yml
+++ b/.gitlab-ci-check-golang-static.yml
@@ -23,7 +23,7 @@ test:static:
   image: golang:1.13
   before_script:
     # Install cyclomatic dependency analysis tool
-    - go get -u github.com/fzipp/gocyclo
+    - GO111MODULE=off go get -u github.com/fzipp/gocyclo
     # Install compile dependencies
     - if [ -f deb-requirements.txt ]; then
         apt-get -qq update &&

--- a/.gitlab-ci-check-golang-unittests.yml
+++ b/.gitlab-ci-check-golang-unittests.yml
@@ -34,8 +34,8 @@ test:unit:
     GIT_DEPTH: 0
   before_script:
     # Install code coverage tooling
-    - go get -u github.com/axw/gocov/gocov
-    - go get -u golang.org/x/tools/cmd/cover
+    - GO111MODULE=off go get -u github.com/axw/gocov/gocov
+    - GO111MODULE=off go get -u golang.org/x/tools/cmd/cover
 
     # Install mongodb for the tests that use it locally
     - apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,8 +35,8 @@ test:unit:
     - cd /go/src/github.com/mendersoftware/mendertesting
 
     # Install code coverage / coveralls tooling
-    - go get -u github.com/axw/gocov/gocov
-    - go get -u golang.org/x/tools/cmd/cover
+    - GO111MODULE=off go get -u github.com/axw/gocov/gocov
+    - GO111MODULE=off go get -u golang.org/x/tools/cmd/cover
 
   script:
     # Test if code was formatted with 'go fmt'


### PR DESCRIPTION
unfortunately go packages can't be installed without changing a projects go.mod
if using a gomod enabled go version
deactivating gomod fixes this

Changelog: None
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>