### PR TITLE
[check_commits] Skip all checks for dependabot commits

### DIFF
--- a/check_commits.sh
+++ b/check_commits.sh
@@ -90,6 +90,11 @@ do
         continue
     fi
 
+    # Ignore commits from dependabot[-preview]
+    if echo "${COMMIT_USER_EMAIL}" | egrep "^dependabot(-preview)?\[bot\] <[0-9]+\+dependabot(-preview)?\[bot\]@users.noreply.github.com>$" >/dev/null; then
+        continue
+    fi
+
     if [ -n ${CHECK_SIGNOFFS} ]; then
         # Check that Signed-off-by tags are present.
         if ! echo "$COMMIT_MSG" | grep -F "Signed-off-by: ${COMMIT_USER_EMAIL}" >/dev/null; then
@@ -98,7 +103,7 @@ do
         fi
     fi
 
-    if [ -n ${CHECK_CHANGELOGS} -a ${COMMIT_USER_EMAIL} != "support@dependabot.com" ]; then
+    if [ -n ${CHECK_CHANGELOGS} ]; then
         # Check that Changelog tags are present.
         if ! echo "$COMMIT_MSG" | grep -i "^ *Changelog:" >/dev/null; then
             echo >&2 "Commit ${i} doesn't have a changelog tag! Make a changelog entry for your commit (https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md#changelog-tags)."


### PR DESCRIPTION
Not only dependabot does not include Changelog tags, but also the commit
sign does not match the Git user.

This commit partially reverts incomplete fix from ffc2e5e and instead
just skips all checks for these commits.