### PR TITLE
QA-184: publish feature Docker images

### DIFF
--- a/.gitlab-ci-check-docker-build.yml
+++ b/.gitlab-ci-check-docker-build.yml
@@ -73,7 +73,7 @@ publish:image:
   stage: publish
   only:
     refs:
-      # NOTE: We can remove master and [0-9]+\.[0-9]+\.x from here after 2.3.x goes EOL
+      # NOTE: We can remove [0-9]+\.[0-9]+\.x from here after 2.3.x goes EOL
       - /^(master|staging|[0-9]+\.[0-9]+\.x)$/
   tags:
     - docker

--- a/.gitlab-ci-check-docker-build.yml
+++ b/.gitlab-ci-check-docker-build.yml
@@ -74,7 +74,7 @@ publish:image:
   only:
     refs:
       # NOTE: We can remove [0-9]+\.[0-9]+\.x from here after 2.3.x goes EOL
-      - /^(master|staging|[0-9]+\.[0-9]+\.x)$/
+      - /^(master|staging|feature-.+|[0-9]+\.[0-9]+\.x)$/
   tags:
     - docker
   image: docker


### PR DESCRIPTION
* [docker-build-template] Keep master tags after 2.3 EOL
Adjust the comment, we still would like to keep the :master tags for any
repo that is not part of a Mender release.

* [docker-build-template] QA-184: publish feature Docker images
Publish Docker images for any branch matching feature-* pattern.