### PR TITLE
[docker-build-template] Publish image on production branch

### DIFF
--- a/.gitlab-ci-check-docker-build.yml
+++ b/.gitlab-ci-check-docker-build.yml
@@ -78,7 +78,7 @@ publish:image:
   only:
     refs:
       # NOTE: We can remove [0-9]+\.[0-9]+\.x from here after 2.3.x goes EOL
-      - /^(master|staging|feature-.+|[0-9]+\.[0-9]+\.x)$/
+      - /^(master|staging|production|feature-.+|[0-9]+\.[0-9]+\.x)$/
   tags:
     - docker
   image: docker


### PR DESCRIPTION
To accommodate for repos that use master/production branches, like
mender-docs-site.