### PR TITLE
Add retries to acceptance/unit tests codecov upload

### DIFF
--- a/.gitlab-ci-check-docker-acceptance.yml
+++ b/.gitlab-ci-check-docker-acceptance.yml
@@ -108,4 +108,12 @@ publish:acceptance:
   before_script:
     - apk add --no-cache bash curl findutils git
   script:
-    - bash -c "bash <(curl -s https://codecov.io/bash) -Z -F acceptance -f ./tests/coverage-acceptance.txt"
+    - curl -s https://codecov.io/bash > /tmp/codecov.bash
+    - chmod +x /tmp/codecov.bash
+    - for i in $(seq 5); do
+        /tmp/codecov.bash -Z -F acceptance -f ./tests/coverage-acceptance.txt;
+        if [ $? -eq 0 ]; then
+          break;
+        fi
+        sleep 1;
+      done

--- a/.gitlab-ci-check-golang-unittests.yml
+++ b/.gitlab-ci-check-golang-unittests.yml
@@ -84,4 +84,12 @@ publish:unittests:
     - apk add --no-cache bash curl findutils git
   script:
     - tar -xvf unit-coverage.tar
-    - bash -c "bash <(curl -s https://codecov.io/bash) -Z -F unittests -s ./tests/unit-coverage"
+    - curl -s https://codecov.io/bash > /tmp/codecov.bash
+    - chmod +x /tmp/codecov.bash
+    - for i in $(seq 5); do
+        /tmp/codecov.bash -Z -F unittests -s ./tests/unit-coverage;
+        if [ $? -eq 0 ]; then
+          break;
+        fi
+        sleep 1;
+      done


### PR DESCRIPTION
It has happened a couple of times that the codecov script fails to
upload the coverage for either acceptance or unit tests, but rerunning
the stage succeeds.
*(This PR is just a suggested temporary solution to the problem)*