### PR TITLE
[coveralls] Set also CI_BRANCH env variable

### DIFF
--- a/.gitlab-ci-check-docker-acceptance.yml
+++ b/.gitlab-ci-check-docker-acceptance.yml
@@ -133,9 +133,10 @@ publish:acceptance:
     #  According to https://docs.coveralls.io/supported-ci-services
     #  we should set CI_NAME, CI_BUILD_NUMBER, etc. But according
     #  to goveralls source code (https://github.com/mattn/goveralls)
-    #  many of these are not supported. Set only CI_PR_NUMBER and
-    #  pass few others are command line arguments.
+    #  many of these are not supported. Set CI_BRANCH, CI_PR_NUMBER,
+    #  and pass few others as command line arguments.
     #  See also https://docs.coveralls.io/api-reference
+    - export CI_BRANCH=${CI_COMMIT_BRANCH}
     - export CI_PR_NUMBER=${CI_COMMIT_BRANCH#pr_}
   script:
     - goveralls

--- a/.gitlab-ci-check-golang-unittests.yml
+++ b/.gitlab-ci-check-golang-unittests.yml
@@ -109,9 +109,10 @@ publish:unittests:
     #  According to https://docs.coveralls.io/supported-ci-services
     #  we should set CI_NAME, CI_BUILD_NUMBER, etc. But according
     #  to goveralls source code (https://github.com/mattn/goveralls)
-    #  many of these are not supported. Set only CI_PR_NUMBER and
-    #  pass few others are command line arguments.
+    #  many of these are not supported. Set CI_BRANCH, CI_PR_NUMBER,
+    #  and pass few others as command line arguments.
     #  See also https://docs.coveralls.io/api-reference
+    - export CI_BRANCH=${CI_COMMIT_BRANCH}
     - export CI_PR_NUMBER=${CI_COMMIT_BRANCH#pr_}
   script:
     - tar -xvf unit-coverage.tar


### PR DESCRIPTION
To prevent reports from "HEAD detached at ..." branches.