### PR TITLE
[apidocs template] Use BUILD_X_Y instead of LATEST/OLDSTABLE

### DIFF
--- a/.gitlab-ci-check-apidocs.yml
+++ b/.gitlab-ci-check-apidocs.yml
@@ -49,33 +49,28 @@ trigger:apidocs:rebuild-mender-api-docs:
     - alias release_tool=$(realpath mender-integration/extra/release_tool.py)
     - apk add --no-cache curl
   script:
-    # Get the current stable release (latest tag matching the N.N.0 pattern)
-    - CURRENT_STABLE=$(cd mender-integration && git tag | egrep -e '^[0-9]+\.[0-9]+\.0$' | sort -V -r | head -n1 | sed -e 's/\.0$/.x/g')
     # Enable the build of the mender-api-docs site versions where this branch is in use
     - BUILD_MASTER="false"
     - BUILD_HOSTED="false"
-    - BUILD_LATEST="false"
-    - BUILD_OLDSTABLE="false"
+    # TODO: Find a way to set up BUILD_X.Y and pass it as curl parameters dynamically
+    - BUILD_2_5="false"
     - for version in $(release_tool  --integration-versions-including ${CI_PROJECT_NAME} --version ${CI_COMMIT_REF_NAME} | cut -d"/" -f2); do
     -   if [ "${version}" == "master" ]; then
     -     BUILD_MASTER="true"
     -   elif [ "${version}" == "staging" ]; then
     -     BUILD_HOSTED="true"
-    -   elif [ "${version}" == "${CURRENT_STABLE}" ]; then
-    -     BUILD_LATEST="true"
-    -   else
-    -     BUILD_OLDSTABLE="true"
+    -   elif [ "${version}" == "2.5.x" ]; then
+    -     BUILD_2_5="true"
     -   fi
     - done
     # Trigger the rebuild of mender-api-docs, if at least one of the build is enabled
-    - if [ "${BUILD_MASTER}" != "false" ] || [ "${BUILD_HOSTED}" != "false" ] || [ "${BUILD_LATEST}" != "false" ] || [ "${BUILD_OLDSTABLE}" != "false" ]; then
-    -   echo "Triggering mender-api-docs rebuild (master ${BUILD_MASTER}, hosted ${BUILD_HOSTED}, latest ${BUILD_LATEST}, oldstable ${BUILD_OLDSTABLE})"
+    - if [ "${BUILD_MASTER}" != "false" ] || [ "${BUILD_HOSTED}" != "false" ] || [ "${BUILD_2_5}" != "false" ] ]; then
+    -   echo "Triggering mender-api-docs rebuild (master ${BUILD_MASTER}, hosted ${BUILD_HOSTED}, 2.5 ${BUILD_2_5})"
     -   curl -v -f -X POST
           -F token=${MENDER_API_DOCS_TRIGGER_TOKEN}
           -F ref=master
           -F variables[BUILD_MASTER]=${BUILD_MASTER}
           -F variables[BUILD_HOSTED]=${BUILD_HOSTED}
-          -F variables[BUILD_LATEST]=${BUILD_LATEST}
-          -F variables[BUILD_OLDSTABLE]=${BUILD_OLDSTABLE}
+          -F variables[BUILD_2_5]=${BUILD_2_5}
           https://gitlab.com/api/v4/projects/20356182/trigger/pipeline
     - fi


### PR DESCRIPTION
The problem with using LATEST/OLDSTABLE is that it was hardcoded in the
mender-api-docs repository, so that for a short while (while the release
is in progress) we would actually be building latest (say, 2.5) while
publishing as oldstable (say, 2.4).

Note that this has not been a problem because as per today we have not
had 2.4/2.3 API docs in production.

A more permanent fix will follow.