### PR TITLE
split docs testing template up to prevent issues with version depreca…

### DIFF
--- a/.gitlab-ci-check-apidocs.yml
+++ b/.gitlab-ci-check-apidocs.yml
@@ -15,24 +15,27 @@
 stages:
   - test
 
-test:apidocs:
+test:apidocs:verify-yaml:
   stage: test
   except:
     - /^saas-[a-zA-Z0-9.]+$/
-  image: node:latest
+  image: python:3-alpine
   before_script:
-    # Install upstream Swagger verifier
-    - npm install -g @apidevtools/swagger-cli
     # Get our own Swagger verifier
-    - apt-get -qq update
-    - apt-get install -qy python3-pip
     - pip3 install pyyaml
     - wget https://raw.githubusercontent.com/mendersoftware/autodocs/master/verify_docs.py
   script:
-    # Verify that the Swagger docs are valid
-    - swagger-cli validate docs/*.yml
     # Verify that the Swagger docs follow the autodeployment requirements
     - python3 verify_docs.py `find docs -name "*.yml"`
+
+test:apidocs:verify-swagger:
+  stage: test
+  except:
+    - /^saas-[a-zA-Z0-9.]+$/
+  image: node:alpine
+  script:
+    # Verify that the Swagger docs are valid
+    - npx @apidevtools/swagger-cli validate docs/*.yml
 
 trigger:apidocs:rebuild-mender-api-docs:
   stage: .post


### PR DESCRIPTION
…tion

- specifically to circumvent python 3.5
& the required build time to bring it into the node image
Changelog: None

Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>