### PR TITLE
[check-apidocs template] Trigger production build/publish/sync

### DIFF
--- a/.gitlab-ci-check-apidocs.yml
+++ b/.gitlab-ci-check-apidocs.yml
@@ -73,14 +73,16 @@ trigger:apidocs:rebuild-mender-api-docs:
     -     BUILD_2_5="true"
     -   fi
     - done
-    # Trigger the rebuild of mender-api-docs, if at least one of the build is enabled
+    # Trigger the rebuilds (master + production) of mender-api-docs, if at least one of the build is enabled
     - if [ "${BUILD_MASTER}" != "false" ] || [ "${BUILD_HOSTED}" != "false" ] || [ "${BUILD_2_5}" != "false" ]; then
     -   echo "Triggering mender-api-docs rebuild (master ${BUILD_MASTER}, hosted ${BUILD_HOSTED}, 2.5 ${BUILD_2_5})"
-    -   curl -v -f -X POST
-          -F token=${MENDER_API_DOCS_TRIGGER_TOKEN}
-          -F ref=master
-          -F variables[BUILD_MASTER]=${BUILD_MASTER}
-          -F variables[BUILD_HOSTED]=${BUILD_HOSTED}
-          -F variables[BUILD_2_5]=${BUILD_2_5}
-          https://gitlab.com/api/v4/projects/20356182/trigger/pipeline
+    -   for ref in master production; do
+    -     curl -v -f -X POST
+            -F token=${MENDER_API_DOCS_TRIGGER_TOKEN}
+            -F ref=$ref
+            -F variables[BUILD_MASTER]=${BUILD_MASTER}
+            -F variables[BUILD_HOSTED]=${BUILD_HOSTED}
+            -F variables[BUILD_2_5]=${BUILD_2_5}
+            https://gitlab.com/api/v4/projects/20356182/trigger/pipeline
+    -   done
     - fi


### PR DESCRIPTION
On any content change, we need to trigger both master (staging) and
production pipelines of mender-api-docs, so that both sites get updated.