### PR TITLE
'*.go' directories do not need to be covered by a license file.

### DIFF
--- a/check_license.sh
+++ b/check_license.sh
@@ -95,7 +95,7 @@ for dep_dir in Godeps/_workspace/src vendor
 do
     if [ -d "$dep_dir" ]
     then
-        for gofile in $(find "$dep_dir" -name '*.go')
+        for gofile in $(find "$dep_dir" -name '*.go' -type f)
         do
             parent_dir="$(dirname "$gofile")"
             found=0


### PR DESCRIPTION
Inspired by this package: https://github.com/nats-io/nats.go

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>