### PR TITLE
[check_license_source_files.sh] Skip vendor dir for Python

### DIFF
--- a/check_license_source_files.sh
+++ b/check_license_source_files.sh
@@ -197,7 +197,7 @@ check_files "${GO_FILES}"
 
 echo >&2 "Checking licenses on all Python files"
 PYTHON_FILES="\
-$(find . -type f \( ! -regex ${LICENSE_HEADERS_IGNORE_FILES_REGEXP} ! -regex '.*\.venv.*' ! -regex '.*build/.*' -name '*.py' \))"
+$(find . -type f \( ! -regex ${LICENSE_HEADERS_IGNORE_FILES_REGEXP} ! -path './vendor/*' ! -regex '.*\.venv.*' ! -regex '.*build/.*' -name '*.py' \))"
 check_files "${PYTHON_FILES}"
 
 exit ${TEST_RESULT}


### PR DESCRIPTION
Some vendored code might contain .py files for which we don't want to
run our license check.