### PR TITLE
gitlab/acceptance: switch to mender-test-containers

### DIFF
--- a/.gitlab-ci-check-docker-acceptance.yml
+++ b/.gitlab-ci-check-docker-acceptance.yml
@@ -48,15 +48,12 @@ test:prepare_acceptance:
     - docker save $DOCKER_REPOSITORY:prtest > tests_image.tar
     - docker build -t $DOCKER_REPOSITORY:pr .
     - docker run --rm --entrypoint "/bin/sh" -v $(pwd):/binary $DOCKER_REPOSITORY:pr -c "cp /usr/bin/${CI_PROJECT_NAME} /binary"
-    - docker build -t testing -f tests/Dockerfile tests
-    - docker save testing > acceptance_testing_image.tar
     - wget https://d1b0l86ne08fsf.cloudfront.net/mender-artifact/master/linux/mender-artifact
     - chmod +x mender-artifact
   artifacts:
     expire_in: 2w
     paths:
       - tests_image.tar
-      - acceptance_testing_image.tar
       - ${CI_PROJECT_NAME}
       - mender-artifact
 
@@ -82,7 +79,6 @@ test:acceptance_tests:
     -   mv keys/private.pem tests/
     - fi
     - docker load -i tests_image.tar
-    - docker load -i acceptance_testing_image.tar
     - if [ -n "$REGISTRY_MENDER_IO_USERNAME" ]; then
     -   docker login -u $REGISTRY_MENDER_IO_USERNAME -p $REGISTRY_MENDER_IO_PASSWORD registry.mender.io
     - fi


### PR DESCRIPTION
don't build and handle an individual testing container for each repo.
repos will use mender-test-containers:acceptance-testing images.

changelog: none

Signed-off-by: Marcin Chalczynski <m.chalczynski@gmail.com>

https://tracker.mender.io/browse/QA-237