### PR TITLE
go fmt outputs empty line, sometimes.

### DIFF
--- a/.gitlab-ci-check-golang-static.yml
+++ b/.gitlab-ci-check-golang-static.yml
@@ -40,7 +40,7 @@ test:static:
     # Test if code was formatted with 'go fmt'
     # Command will format code and return modified files
     # fail if any have been modified.
-    - if [ -n "$(go fmt ./...)" ]; then echo 'Code is not formatted with "go fmt"'; false; fi
+    - if [ -n "$(go fmt ./... | grep -v ^$)" ]; then echo 'Code is not formatted with "go fmt"'; false; fi
     # Perform static code analysys
     - go vet `go list ./... | grep -v vendor`
     # Fail builds when the cyclomatic complexity reaches 20 or more


### PR DESCRIPTION
example job:
https://gitlab.com/Northern.tech/Mender/go-lib-micro/-/jobs/971381446

from this pr:
https://github.com/mendersoftware/go-lib-micro/pull/100

and indeed it happens:
```
#echo "$(go fmt ./...)"

```

ChangeLog:none
Signed-off-by: Peter Grzybowski <peter@northern.tech>