### PR TITLE
 [check-docker-*] Replace only/except with modern rules (+ cleanup)

### DIFF
--- a/.gitlab-ci-check-docker-acceptance.yml
+++ b/.gitlab-ci-check-docker-acceptance.yml
@@ -35,8 +35,9 @@ stages:
 test:prepare_acceptance:
   stage: test_prep
   image: docker
-  except:
-    - /^saas-[a-zA-Z0-9.]+$/
+  rules:
+    - if: '$CI_COMMIT_TAG =~ /^saas-[a-zA-Z0-9.]+$/'
+      when: never
   services:
     - docker:19.03.5-dind
   before_script:
@@ -62,8 +63,9 @@ test:prepare_acceptance:
 
 test:acceptance_tests:
   stage: test
-  except:
-    - /^saas-[a-zA-Z0-9.]+$/
+  rules:
+    - if: '$CI_COMMIT_TAG =~ /^saas-[a-zA-Z0-9.]+$/'
+      when: never
   tags:
     - docker
   image: tiangolo/docker-with-compose
@@ -100,8 +102,9 @@ test:acceptance_tests:
 
 publish:acceptance:
   stage: publish
-  except:
-    - /^saas-[a-zA-Z0-9.]+$/
+  rules:
+    - if: '$CI_COMMIT_TAG =~ /^saas-[a-zA-Z0-9.]+$/'
+      when: never
   image: golang:1.14-alpine3.11
   dependencies:
     - test:acceptance_tests

--- a/.gitlab-ci-check-docker-build.yml
+++ b/.gitlab-ci-check-docker-build.yml
@@ -61,8 +61,9 @@ stages:
 
 build:docker:
   stage: build
-  except:
-    - /^saas-[a-zA-Z0-9.]+$/
+  rules:
+    - if: '$CI_COMMIT_TAG =~ /^saas-[a-zA-Z0-9.]+$/'
+      when: never
   tags:
     - docker
   image: docker
@@ -85,12 +86,9 @@ build:docker:
 
 publish:image:
   stage: publish
-  except:
-    - /^saas-[a-zA-Z0-9.]+$/
-  only:
-    refs:
-      # NOTE: We can remove [0-9]+\.[0-9]+\.x from here after 2.3.x goes EOL
-      - /^(master|staging|production|feature-.+|[0-9]+\.[0-9]+\.x)$/
+  rules:
+    # NOTE: We can remove [0-9]+\.[0-9]+\.x from here after 2.3.x goes EOL
+    - if: '$CI_COMMIT_BRANCH =~ /^(master|staging|production|feature-.+|[0-9]+\.[0-9]+\.x)$/'
   tags:
     - docker
   image: docker
@@ -114,9 +112,8 @@ publish:image:
 
 publish:image:mender:
   stage: publish
-  only:
-    refs:
-      - /^(master|[0-9]+\.[0-9]+\.x)$/
+  rules:
+    - if: '$CI_COMMIT_BRANCH =~ /^(master|[0-9]+\.[0-9]+\.x)$/'
   tags:
     - docker
   image: docker
@@ -157,9 +154,8 @@ publish:image:mender:
 
 trigger:saas:sync-staging-component:
   stage: .post
-  only:
-    refs:
-      - /^staging$/
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "staging"'
   image: alpine
   before_script:
     - *export_docker_vars
@@ -186,9 +182,8 @@ trigger:saas:sync-staging-component:
 # saas-specific job to retag docker images after saas-* tags are pushed to the repository
 publish:image:saas:
   stage: publish
-  only:
-    refs:
-      - /^saas-[a-zA-Z0-9.]+$/
+  rules:
+    - if: '$CI_COMMIT_TAG =~ /^saas-[a-zA-Z0-9.]+$/'
   tags:
     - docker
   image: docker

--- a/.gitlab-ci-check-docker-build.yml
+++ b/.gitlab-ci-check-docker-build.yml
@@ -87,8 +87,7 @@ build:docker:
 publish:image:
   stage: publish
   rules:
-    # NOTE: We can remove [0-9]+\.[0-9]+\.x from here after 2.3.x goes EOL
-    - if: '$CI_COMMIT_BRANCH =~ /^(master|staging|production|feature-.+|[0-9]+\.[0-9]+\.x)$/'
+    - if: '$CI_COMMIT_BRANCH =~ /^(master|staging|production|feature-.+)$/'
   tags:
     - docker
   image: docker

--- a/.gitlab-ci-check-docker-deploy.yml
+++ b/.gitlab-ci-check-docker-deploy.yml
@@ -28,12 +28,11 @@
 #   INFRA_REPOSITORY: <git@github.com:mendersoftware/other-repo.git> (optional)
 #   INFRA_BRANCH: <other-branch> (optional)
 #
-# By default, it only runs on master branch, override only tag to modify
-# behaviour, for example with a regex:
+# By default, it only runs on master branch, override rules tag to modify
+# behavior, for example with a regex:
 #
-# only:
-#   refs:
-#     - /^(master|staging|production|feature-.+|[0-9]+\.[0-9]+\.x)$/
+# rules:
+#   - if: '$CI_COMMIT_BRANCH =~ /^(master|staging|production|feature-.+|[0-9]+\.[0-9]+\.x)$/'
 #
 
 stages:
@@ -51,9 +50,8 @@ variables:
   DEBIAN_FRONTEND: noninteractive
 
 sync:image:
-  only:
-    refs:
-      - master
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "master"'
   dependencies:
     - publish:image
   stage: sync


### PR DESCRIPTION
* [check-docker-*] Replace only/except with modern rules
The main motivation is to have an easier way to override rules by user
pipelines.
According to GitLab documentation only/except are not going to be
developed further, so better to switch to the new standard.

* [check-docker-build] Deprecate publishing :M.N.x tags
Since Mender 2.3 went EOL, there is no more use for these tags (we now
publish release branches using :mender-M.N.x tags)