### PR TITLE
[check-docker-*] Amend rules

### DIFF
--- a/.gitlab-ci-check-docker-acceptance.yml
+++ b/.gitlab-ci-check-docker-acceptance.yml
@@ -38,6 +38,7 @@ test:prepare_acceptance:
   rules:
     - if: '$CI_COMMIT_TAG =~ /^saas-[a-zA-Z0-9.]+$/'
       when: never
+    - when: on_success
   services:
     - docker:19.03.5-dind
   before_script:
@@ -66,6 +67,7 @@ test:acceptance_tests:
   rules:
     - if: '$CI_COMMIT_TAG =~ /^saas-[a-zA-Z0-9.]+$/'
       when: never
+    - when: on_success
   tags:
     - docker
   image: tiangolo/docker-with-compose
@@ -105,6 +107,7 @@ publish:acceptance:
   rules:
     - if: '$CI_COMMIT_TAG =~ /^saas-[a-zA-Z0-9.]+$/'
       when: never
+    - when: on_success
   image: golang:1.14-alpine3.11
   dependencies:
     - test:acceptance_tests

--- a/.gitlab-ci-check-docker-build.yml
+++ b/.gitlab-ci-check-docker-build.yml
@@ -64,6 +64,7 @@ build:docker:
   rules:
     - if: '$CI_COMMIT_TAG =~ /^saas-[a-zA-Z0-9.]+$/'
       when: never
+    - when: on_success
   tags:
     - docker
   image: docker


### PR DESCRIPTION
When no match, rules default to not adding the job in the pipeline. So
all the jobs that were excluded for saas tags require a final catch all
rule for them to be included in the pipelines.

Amends commit 431bc37f452d155ef555852315ba947f67fac1c5