### PR TITLE
[docker-build/deploy] Switch from dependencies to needs

### DIFF
--- a/.gitlab-ci-check-docker-build.yml
+++ b/.gitlab-ci-check-docker-build.yml
@@ -61,6 +61,7 @@ stages:
 
 build:docker:
   stage: build
+  needs: []
   rules:
     - if: '$CI_COMMIT_TAG =~ /^saas-[a-zA-Z0-9.]+$/'
       when: never
@@ -94,8 +95,9 @@ publish:image:
   image: docker
   services:
     - docker:19.03.5-dind
-  dependencies:
-    - build:docker
+  needs:
+    - job: build:docker
+      artifacts: true
   before_script:
     - *export_docker_vars
     - *docker_login_registries
@@ -119,8 +121,9 @@ publish:image:mender:
   image: docker
   services:
     - docker:19.03.5-dind
-  dependencies:
-    - build:docker
+  needs:
+    - job: build:docker
+      artifacts: true
   before_script:
     # Use same variables for loading the image, while DOCKER_PUBLISH_COMMIT_TAG will be ignored
     - *export_docker_vars

--- a/.gitlab-ci-check-docker-deploy.yml
+++ b/.gitlab-ci-check-docker-deploy.yml
@@ -52,8 +52,9 @@ variables:
 sync:image:
   rules:
     - if: '$CI_COMMIT_BRANCH == "master"'
-  dependencies:
-    - publish:image
+  needs:
+    - job: publish:image
+      artifacts: true
   stage: sync
   image: debian:buster
   before_script:


### PR DESCRIPTION
Main motivation is to specify empty needs for docker build, so that this
can start without waiting for previous stages to complete.