### PR TITLE
Fix: api-docs-site trigger BUILD_X_Y variables

### DIFF
--- a/.gitlab-ci-check-apidocs.yml
+++ b/.gitlab-ci-check-apidocs.yml
@@ -72,7 +72,7 @@ trigger:apidocs:rebuild-mender-api-docs:
     -     BUILD_HOSTED="true"
     -   elif echo $version | egrep -q -e '^[0-9.x]+$'; then
     -     VERSION_VAR_NAME=BUILD_$(echo $version | tr '.' '_' | sed -e 's/_x$//')
-    -     BUILD_VARS="${BUILD_VARS} -F ${VERSION_VAR_NAME}=true"
+    -     BUILD_VARS="${BUILD_VARS} -F variables[${VERSION_VAR_NAME}]=true"
     -   fi
     - done
     # Trigger the rebuilds (master + production) of mender-api-docs, if at least one of the build is enabled


### PR DESCRIPTION
Changelog: none

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>