### PR TITLE
[docker-acceptance] Improve support on repos using common tester image

### DIFF
--- a/.gitlab-ci-check-docker-acceptance.yml
+++ b/.gitlab-ci-check-docker-acceptance.yml
@@ -101,6 +101,8 @@ test:acceptance_tests:
     paths:
       - tests/acceptance.*
       - tests/coverage-acceptance.txt
+    reports:
+      junit: tests/results.xml
     when: always
 
 publish:acceptance:

--- a/.gitlab-ci-check-docker-acceptance.yml
+++ b/.gitlab-ci-check-docker-acceptance.yml
@@ -51,15 +51,17 @@ test:prepare_acceptance:
     - docker save $DOCKER_REPOSITORY:prtest > tests_image.tar
     - docker build -t $DOCKER_REPOSITORY:pr .
     - docker run --rm --entrypoint "/bin/sh" -v $(pwd):/binary $DOCKER_REPOSITORY:pr -c "cp /usr/bin/${CI_PROJECT_NAME} /binary"
-    - docker build -t testing -f tests/Dockerfile tests
-    - docker save testing > acceptance_testing_image.tar
+    # Repos using common tester image might not have the Dockerfile
+    - if [ -f tests/Dockerfile ]; then
+    -   docker build -t testing -f tests/Dockerfile tests
+    -   docker save testing > acceptance_testing_image.tar
+    - fi
     - wget https://d1b0l86ne08fsf.cloudfront.net/mender-artifact/master/linux/mender-artifact
     - chmod +x mender-artifact
   artifacts:
     expire_in: 2w
     paths:
-      - tests_image.tar
-      - acceptance_testing_image.tar
+      - '*_image.tar'
       - ${CI_PROJECT_NAME}
       - mender-artifact
 
@@ -87,7 +89,10 @@ test:acceptance_tests:
     -   mv keys/private.pem tests/
     - fi
     - docker load -i tests_image.tar
-    - docker load -i acceptance_testing_image.tar
+    # Repos using common tester image might not have the Dockerfile
+    - if [ -f tests/Dockerfile ]; then
+    -   docker load -i acceptance_testing_image.tar
+    - fi
     - if [ -n "$REGISTRY_MENDER_IO_USERNAME" ]; then
     -   docker login -u $REGISTRY_MENDER_IO_USERNAME -p $REGISTRY_MENDER_IO_PASSWORD registry.mender.io
     - fi


### PR DESCRIPTION
So far the repos that have been migrated have kept a dummy Dockerfile
just to satisfy the template. Just check for the file here instead.

Extra:
* [docker-acceptance] Collect results as GitLab junit report