### PR TITLE
[pipeline] Remove codecov integration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,6 @@ include:
 
 stages:
   - test
-  - publish
 
 # See QA-274
 # test:lint:
@@ -62,13 +61,3 @@ test:unit:
     expire_in: 2w
     paths:
       - coverage.txt
-
-publish:tests:
-  image: alpine
-  stage: publish
-  before_script:
-    - apk add --no-cache bash curl findutils git
-  dependencies:
-    - test:unit
-  script:
-    - bash -c "bash <(curl -s https://codecov.io/bash) -Z"


### PR DESCRIPTION
This go code is not in use anyway, and seems like this is the only repo
still using codecov.