### PR TITLE
[docker templates] Revert to "dependencies" for publishing jobs

### DIFF
--- a/.gitlab-ci-check-docker-build.yml
+++ b/.gitlab-ci-check-docker-build.yml
@@ -96,9 +96,8 @@ publish:image:
   image: docker
   services:
     - docker:19.03.5-dind
-  needs:
-    - job: build:docker
-      artifacts: true
+  dependencies:
+    - build:docker
   before_script:
     - *export_docker_vars
     - *docker_login_registries
@@ -122,9 +121,8 @@ publish:image:mender:
   image: docker
   services:
     - docker:19.03.5-dind
-  needs:
-    - job: build:docker
-      artifacts: true
+  dependencies:
+    - build:docker
   before_script:
     # Use same variables for loading the image, while DOCKER_PUBLISH_COMMIT_TAG will be ignored
     - *export_docker_vars

--- a/.gitlab-ci-check-docker-deploy.yml
+++ b/.gitlab-ci-check-docker-deploy.yml
@@ -52,9 +52,8 @@ variables:
 sync:image:
   rules:
     - if: '$CI_COMMIT_BRANCH == "master"'
-  needs:
-    - job: publish:image
-      artifacts: true
+  dependencies:
+    - publish:image
   stage: sync
   image: debian:buster
   before_script:


### PR DESCRIPTION
This partially reverts 09f6522e, resulting a mix of "needs" for the
build job and "dependencies" for publish jobs. The motivation is that we
shall not publish containers if there is any job failing in a previous
stage.

Reasoning can be found at:
https://github.com/mendersoftware/gui/pull/1603#issuecomment-843841981

Changelog: None

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>