### PR TITLE
check_license.sh: Print shasum output when mismatches

### DIFF
--- a/check_license.sh
+++ b/check_license.sh
@@ -54,6 +54,9 @@ TMP_CHKSUM_FILE=$(mktemp)
 trap cleanup EXIT
 cleanup()
 {
+  if [ -n "$output" ]; then
+    echo "$output"
+  fi
   rm $TMP_CHKSUM_FILE
 }
 sed '/^$/d' $CHKSUM_FILE > $TMP_CHKSUM_FILE

--- a/check_license.sh
+++ b/check_license.sh
@@ -29,8 +29,7 @@ while [ -n "$1" ]; do
             file="${1#--add-license=}"
             KNOWN_LICENSE_FILES="$KNOWN_LICENSE_FILES $file"
             # The file must exist in LIC_FILES_CHKSUM.sha256
-            if ! fgrep -q "$file" $CHKSUM_FILE
-            then
+            if ! fgrep -q "$file" $CHKSUM_FILE; then
                 echo "$file does not have a checksum in $CHKSUM_FILE"
                 exit 1
             fi
@@ -43,8 +42,7 @@ while [ -n "$1" ]; do
     shift
 done
 
-if [ -n "$1" ]
-then
+if [ -n "$1" ]; then
     cd "$1"
 fi
 
@@ -52,12 +50,11 @@ fi
 # errors by the shasum program
 TMP_CHKSUM_FILE=$(mktemp)
 trap cleanup EXIT
-cleanup()
-{
-  if [ -n "$output" ]; then
-    echo "$output"
-  fi
-  rm $TMP_CHKSUM_FILE
+cleanup() {
+    if [ -n "$output" ]; then
+        echo "$output"
+    fi
+    rm $TMP_CHKSUM_FILE
 }
 sed '/^$/d' $CHKSUM_FILE > $TMP_CHKSUM_FILE
 
@@ -65,28 +62,28 @@ sed '/^$/d' $CHKSUM_FILE > $TMP_CHKSUM_FILE
 CHKSUM_FILE=$TMP_CHKSUM_FILE
 
 # Collect only stderr from the subcommand
-output="$(exec 3>&1; shasum --warn --algorithm 256 --check $CHKSUM_FILE >/dev/null 2>&3)"
+output="$(
+          exec 3>&1
+          shasum --warn --algorithm 256 --check $CHKSUM_FILE > /dev/null 2>&3
+)"
 
 if echo "$output" | grep -q 'line is improperly formatted' -; then
-  echo >&2 "Some line(s) in the LIC_FILE_CHKSUM.sha256 file are misformed"
-  cat $CHKSUM_FILE
-  exit 1
+    echo >&2 "Some line(s) in the LIC_FILE_CHKSUM.sha256 file are misformed"
+    cat $CHKSUM_FILE
+    exit 1
 fi
 
 # Unlisted licenses not allowed.
-for file in $(find . -iname 'LICEN[SC]E' -o -iname 'LICEN[SC]E.*' -o -iname 'COPYING')
-do
+for file in $(find . -iname 'LICEN[SC]E' -o -iname 'LICEN[SC]E.*' -o -iname 'COPYING'); do
     file=$(echo $file | sed -e 's,./,,')
-    if ! fgrep "$(shasum -a 256 $file)" $CHKSUM_FILE > /dev/null
-    then
+    if ! fgrep "$(shasum -a 256 $file)" $CHKSUM_FILE > /dev/null; then
         echo >&2 "$file has missing or wrong entry in $CHKSUM_FILE"
         ret=1
     fi
 done
 
 # There must be a license at the top level.
-if [ LICENSE* = "LICENSE*" ] && [ COPYING* = "COPYING*" ]
-then
+if [ LICENSE* = "LICENSE*" ] && [ COPYING* = "COPYING*" ]; then
     echo "No top level license file."
     ret=1
 fi
@@ -94,28 +91,21 @@ fi
 # There must be a license at the top level of each Go dependency.
 # The logic is so that each .go source file must have a license file in the same
 # directory, or in a parent directory.
-if [ -d vendor ]
-then
-    for gofile in $(find vendor -name '*.go' -type f)
-    do
+if [ -d vendor ]; then
+    for gofile in $(find vendor -name '*.go' -type f); do
         parent_dir="$(dirname "$gofile")"
         found=0
-        while [ "$parent_dir" != "vendor" ]
-        do
+        while [ "$parent_dir" != "vendor" ]; do
             # Either we need to find a license file, or the file must be
             # covered by one of the license files specified in
             # KNOWN_LICENSE_FILES.
-            if [ $(find "$parent_dir" -maxdepth 1 -iname 'LICEN[SC]E' -o -iname 'LICEN[SC]E.*' -o -iname 'COPYING' | wc -l) -ge 1 ]
-            then
+            if [ $(find "$parent_dir" -maxdepth 1 -iname 'LICEN[SC]E' -o -iname 'LICEN[SC]E.*' -o -iname 'COPYING' | wc -l) -ge 1 ]; then
                 found=1
                 break
             fi
-            if [ -n "$KNOWN_LICENSE_FILES" ]
-            then
-                for known_file in $KNOWN_LICENSE_FILES
-                do
-                    if [ "$(dirname $known_file)" = "$parent_dir" ]
-                    then
+            if [ -n "$KNOWN_LICENSE_FILES" ]; then
+                for known_file in $KNOWN_LICENSE_FILES; do
+                    if [ "$(dirname $known_file)" = "$parent_dir" ]; then
                         found=1
                         break 2
                     fi
@@ -123,8 +113,7 @@ then
             fi
             parent_dir="$(dirname "$parent_dir")"
         done
-        if [ $found != 1 ]
-        then
+        if [ $found != 1 ]; then
             echo "No license file to cover $gofile"
             ret=1
             break


### PR DESCRIPTION
On checksum mismatch shasum returns non-zero and the script exists
silently. Now it will print the warning before clean-up.
For example: "shasum: WARNING: 1 computed checksum did NOT match"