### PR TITLE
QA-235: Add new template .gitlab-ci-check-golang-lint.yml

### DIFF
--- a/.gitlab-ci-check-golang-lint.yml
+++ b/.gitlab-ci-check-golang-lint.yml
@@ -1,0 +1,42 @@
+# .gitlab-ci-check-golang-lint.yml
+#
+# This gitlab-ci template performs all static checks from golangci-lint,
+# see https://github.com/golangci/golangci-lint
+#
+# Add it to the project in hand through Gitlab's include functionality
+#
+# include:
+#   - project: 'Northern.tech/Mender/mendertesting'
+#     file: '.gitlab-ci-check-golang-lint.yml'
+#
+# The standard .golangci.yml from this repository is used unless the
+# project including this template has its own version in the root dir.
+#
+# If the repo has some compile time dependencies, the template expect to
+# exist a deb-requirements.txt file with the Debian OS required packages
+#
+
+stages:
+  - test
+
+test:static:
+  stage: test
+  needs: []
+  except:
+    - /^saas-[a-zA-Z0-9.]+$/
+  image: golangci/golangci-lint:v1.43.0
+  before_script:
+    # Install compile dependencies
+    - if [ -f deb-requirements.txt ]; then
+        apt-get -qq update &&
+        apt install -yq $(cat deb-requirements.txt);
+      fi
+    # Copy .golangci.yml
+    - if [ ! -f .golangci.yml ]; then
+    -   curl -f
+          https://raw.githubusercontent.com/mendersoftware/mendertesting/master/.golangci.yml
+          --output .golangci.yml
+    -   sed -i "s/#CI_PROJECT_NAME#/${CI_PROJECT_NAME}/g" .golangci.yml
+    - fi
+  script:
+    - golangci-lint run -v

--- a/.gitlab-ci-check-golang-static.yml
+++ b/.gitlab-ci-check-golang-static.yml
@@ -1,5 +1,7 @@
 # .gitlab-ci-check-golang-static.yml
 #
+# NOTE: This template is deprecated, use .gitlab-ci-check-golang-lint.yml
+#
 # This gitlab-ci template performs the following static checks on Go code:
 # - check format with go fmt
 # - check code health with go vet

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,47 @@
+run:
+  # timeout for analysis, e.g. 30s, 5m, default is 1m
+  timeout: 5m
+
+  # Skip linting _test.go files
+  tests: false
+
+  # Enables skipping of directories:
+  # vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
+  skip-dirs-use-default: true
+
+  # Allow multiple parallel golangci-lint instances running.
+  # If false (default) - golangci-lint acquires file lock on start.
+  allow-parallel-runners: true
+
+linters:
+  enable:
+    - bodyclose
+    - deadcode
+    - errcheck
+    - gocyclo
+    - gofmt
+    - gosimple
+    - govet
+    - ineffassign
+    - lll
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unused
+    - varcheck
+
+linters-settings:
+  gocyclo:
+    # default is 30.
+    min-complexity: 20
+
+  goimports:
+    # to be edited by the template
+    local-prefixes:
+      "github.com/mendersoftware/#CI_PROJECT_NAME#"
+
+  lll:
+    # max line length, lines longer will be reported. Default is 120.
+    line-length: 100
+    # tab width in spaces. Default to 1.
+    tab-width: 4


### PR DESCRIPTION
This template is meant to replace .gitlab-ci-check-golang-static.yml,
but changing the linters there will terribly break all release branches
of many repositories.

Adding a new template instead and making a note on not using the old
one.