### PR TITLE
.golangci.yml: Add missing goimports linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,6 +20,7 @@ linters:
     - errcheck
     - gocyclo
     - gofmt
+    - goimports
     - gosimple
     - govet
     - ineffassign


### PR DESCRIPTION
Missing from commit 33155db.