### PR TITLE
QA-363: Enable semantic commits checking

### DIFF
--- a/.gitlab-ci-check-commits.yml
+++ b/.gitlab-ci-check-commits.yml
@@ -22,7 +22,11 @@ test:check-commits:
     - git fetch origin 'refs/heads/*:refs/heads/*'
     # Get last remaining tags, if any.
     - git fetch --tags origin
-    - git clone --depth=1 http://github.com/mendersoftware/mendertesting /tmp/mendertesting
+    - if [ "${CI_PROJECT_NAME}" = "mendertesting" ]; then
+    -   git clone --shared --local . /tmp/mendertesting
+    - else
+    -   git clone --depth=1 http://github.com/mendersoftware/mendertesting /tmp/mendertesting
+    - fi
   script:
     # Check commit compliance.
     - /tmp/mendertesting/check_commits.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,3 +53,12 @@ test:unit:
     expire_in: 2w
     paths:
       - coverage.txt
+
+
+test:unit:commitlint:
+  image: ubuntu:20.04
+  stage: test
+  before_script:
+    - apt-get update && apt-get -y install gawk
+  script:
+    - commitlint/testcommitlint.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,9 @@ include:
 stages:
   - test
 
+variables:
+  UNVERSIONED_REPOSITORY: "true"
+
 test:unit:
   image: golang:1.14
   stage: test

--- a/check_commits.sh
+++ b/check_commits.sh
@@ -72,7 +72,7 @@ fi
 
 if [ -n "$1" ]
 then
-    echo "Checking range: $@:"
+    echo >&2 "Checking range: $@:"
     git --no-pager log "$@"
     commits="$(git rev-list --no-merges "$@")"
 else

--- a/commitlint/commitlint
+++ b/commitlint/commitlint
@@ -1,0 +1,327 @@
+#! /usr/bin/awk -f
+
+# TOKENS = COMMIT_TYPE | COMMIT_SCOPE | HEADER | BODY | FOOTER
+#
+# Grammar
+#
+# HEADER = type[(COMMIT_SCOPE)]: TITLE
+# EMPTY_LINE
+# BODY
+# EMPTY LINE
+# FOOTER
+#
+
+BEGIN {
+    # TOKENS
+
+    ## Header
+    COMMIT_TYPE = "^(fix|feat|build|chore|ci|docs|perf|refac|revert|style|test)"
+    LINE=".*"
+    WORD = "[[:print:]]+"
+    COMMIT_SCOPE = "^\\("WORD"\\)"
+    EMPTY_LINE = "^$"
+
+    ## Footer
+    CHANGELOG_PREFIX="Changelog(\\((fix|feat)+\\))?: "
+    CHANGELOG=CHANGELOG_PREFIX ".*"
+    TICKET="Ticket: .*"
+    BREAKING_CHANGE="BREAKING[- ]CHANGE: .*"
+    SIGN_OFF_LINE="Signed-off-by: .*"
+    CHERRY_PICK="(cherry picked from commit .*)"
+
+    ## special
+    COLON = "^:"
+    EOF = "E_O_F"
+
+    # Initialize the lexer
+    init_lexer()
+
+    # Parse the entire commit
+    parse()
+
+    # Enforce our own custom checks
+    lint()
+
+}
+
+function debugf(format, expr1, expr2, expr3, expr4, expr5) {
+    if (DEBUG == "true") {
+        l = sprintf(format, expr1, expr2, expr3, expr4, expr5)
+        printf "Debug: " l "\n" | "cat 1>&2"
+    }
+}
+
+function perror(format, expr1, expr2, expr3, expr4, expr5) {
+    l = sprintf(format, expr1, expr2, expr3, expr4, expr5)
+    printf "Error: " l "\n" | "cat 1>&2"
+}
+
+function error(format, expr1, expr2, expr3, expr4, expr5) {
+    l = sprintf(format, expr1, expr2, expr3, expr4, expr5)
+    printf "Error: " l "\n" | "cat 1>&2"; exit 1
+}
+
+function init_lexer() {
+    advance()
+}
+
+# advance
+#
+# LL1 lexer (1 lookahead)
+#
+# Produces
+#
+# tok
+# next_tok
+#
+function advance() {
+    _advance()
+    tok = next_tok
+    next_tok = _tok
+}
+
+function _advance() {
+    debugf("%d advance: line '%s'", NR, line)
+    if (_tok == EOF)  return _tok;
+    if (length(line) == 0) {
+        if (getline line == 0) {
+            _tok = EOF
+            return EOF
+        }
+    }
+    if (match(line, COMMIT_TYPE) != 0) {
+        debugf("Matched COMMIT_TYPE: %s", line)
+        _tok = substr(line, 1, RLENGTH)
+        line = substr(line, RLENGTH+1)
+        return _tok
+    }
+    if (match(line, COMMIT_SCOPE)) {
+        debugf("Matched COMMIT_SCOPE")
+        _tok = substr(line, 0, RLENGTH)
+        line = substr(line, RLENGTH+1)
+        return _tok
+    }
+    if (match(line, COLON)) {
+        debugf("COLON: '%s'", line)
+        _tok = substr(line, 1, RLENGTH)
+        line = substr(line, RLENGTH+1)
+        VAL = _tok;
+        return _tok
+    }
+    if (match(line, CHANGELOG)) {
+        debugf("Matched Changelog!")
+        _tok = line
+        VAL = _tok;
+        line = ""
+        return _tok
+    }
+    if (match(line, TICKET)) {
+        debugf("Matched Ticket!")
+        _tok = line
+        VAL = _tok;
+        line = ""
+        return _tok
+    }
+    if (match(line, BREAKING_CHANGE)) {
+        debugf("Matched BREAKING CHANGE!")
+        _tok = line
+        VAL = _tok;
+        line = ""
+        return _tok
+    }
+    if (match(line, LINE)) {
+        debugf("Matched LINE!")
+        _tok = line
+        VAL = _tok
+        line = ""
+        return _tok
+    }
+    error("No matches found. This is unexpected")
+}
+
+# consume
+#
+# Consume sets CONSUMED_VAL to tok's token value
+# if tok matches the expected token type
+#
+function consume(expect, err_msg) {
+    debugf("consuming: %s", expect)
+    if (!match(tok, expect)) {
+        if (err_msg != "") {
+            perror(err_msg)
+        }
+        error("got token '%s', expected '%s'", tok, expect)
+    }
+    CONSUMED_VAL = tok
+    advance()
+}
+
+# Parse TITLE
+#
+# WORD [ | WORD ]*
+# (Really just the remainder of the line)
+function parse_title() {
+    consume(LINE)
+    TITLE_VAL=CONSUMED_VAL
+}
+
+# Parse HEADER
+#
+# COMMIT_TYPE [(COMMIT_SCOPE)] COLON
+#
+function parse_header() {
+    advance()
+    consume(COMMIT_TYPE)
+    COMMIT_TYPE_VAL = CONSUMED_VAL;
+    if (match(tok, COMMIT_SCOPE)) {
+        consume(COMMIT_SCOPE)
+        COMMIT_SCOPE_VAL = CONSUMED_VAL
+    }
+    consume(COLON) # End of prefix
+    parse_title()
+}
+
+function empty_line(err_msg) {
+    if (tok == EOF) {
+        return
+    }
+    consume(EMPTY_LINE, err_msg)
+}
+
+# Parse BODY
+#
+# [WORD [ (| WORD )*]
+#
+function parse_body() {
+    if (tok == EOF) {
+        return
+    }
+    BODY_VAL=tok
+    advance()
+    # Consume the remainder of the body
+    while (tok != EOF && !is_footer(next_tok)) {
+        advance()
+    }
+    return
+}
+
+# Parse FOOTER
+#
+# [BREAKING_CHANGE]
+# [CHANGELOG]
+# [TICKET]
+#
+function parse_footer() {
+
+    if (tok == EOF) {
+        return
+    }
+    while (tok != EOF) {
+        if ( ! (match(tok, CHANGELOG) ||
+                match(tok, TICKET) ||
+                match(tok, BREAKING_CHANGE) ||
+                match(tok, EMPTY_LINE) ||
+                match(tok, CHERRY_PICK) ||
+                match(tok, SIGN_OFF_LINE))) {
+            error("Only Changelogs, Tickets, Sign-offs, cherry pick notes and BREAKING CHANGES allowed in the FOOTER")
+        }
+        if (match(tok, CHANGELOG)) {
+            CHANGELOG_VAL=tok
+            verify_changelog(tok)
+        }
+        if (match(tok, TICKET)) {
+            TICKET_VAL=tok
+            verify_ticket_id(tok)
+        }
+        if (match(tok, BREAKING_CHANGE)) {
+            BREAKING_CHANGE_VAL=tok
+        }
+        advance()
+    }
+    return
+}
+
+function is_footer(token) {
+    return match(token, CHANGELOG) || match(token, TICKET) || match(token, BREAKING_CHANGE)
+}
+
+function parse() {
+
+    parse_header()
+
+    # expect empty line before the body
+    empty_line("The commit must have one line of air in between the header and the body")
+
+    #
+    # BODY (optional)
+    #
+    if (! tok != EOF && ! is_footer(next_tok)) {
+
+        # BODY
+        parse_body()
+
+        # Expect empty line between body and footer
+        empty_line("The commit must have one line of air in between the body and the footer")
+    }
+
+    # FOOTER
+    parse_footer()
+
+}
+
+# lint
+#
+# Verify that the commit structure conforms to our grammar
+#
+# Requires parse() to have run first.
+function lint() {
+    # fix, feat, BREAKING CHANGE requries a ticket, and a changelog in the footer
+    if (match(COMMIT_TYPE_VAL, "fix|feat") || BREAKING_CHANGE_VAL != "") {
+        lint_required_footer_values()
+        return
+    }
+}
+
+# lint_required_footer_values
+#
+# Make sure that a Changelog, and a Ticket reference is
+# included in the commit footer if required.
+#
+function lint_required_footer_values() {
+    if (CHANGELOG_VAL == "") {
+        error("A 'Changelog' is required for the given commit")
+    }
+    if (TICKET_VAL == "") {
+        error("A 'Ticket' is required for the given commit")
+    }
+}
+
+# verify_changelog
+#
+# Verify that the Changelog is set correctly
+# It has to be either:
+# * Commit
+# * All
+# * None
+# * Title
+function verify_changelog(changelog) {
+    # Strip the CHANGELOG[(fix|feat)] prefix
+    gsub(CHANGELOG_PREFIX, "", changelog)
+    if ( match(changelog, "(None|Title|Commit|All|\\S+(\\s+\\S+){2,})") == 0 ) {
+        error("Misspelled word in Changelog")
+    }
+}
+
+# verify_ticket
+#
+# Verify that the ticket_id is set correctly
+# It has to be either:
+# * None
+# * Ticket ID (<project><dash><numbers>)
+function verify_ticket_id(ticket_id) {
+    # Strip the 'Ticket: ' prefix
+    gsub("Ticket: ", "", ticket_id)
+    if ( match(ticket_id, "\\s*(None|\\S+-[0-9]+)") == 0 ) {
+        error("Misspelled word in the 'Ticket: <word>'")
+    }
+}

--- a/commitlint/grammar.md
+++ b/commitlint/grammar.md
@@ -1,0 +1,192 @@
+# Mender conventional commit specification
+
+```
+<type>(<scope>): <subject>
+<BLANK LINE>
+<body>
+<BLANK LINE>
+<footer>
+```
+
+# Specification
+
+    1. Commits MUST be prefixed with a type, which consists of a noun, feat, fix, etc., followed by the OPTIONAL scope, and REQUIRED terminal colon and space (See #allowed-types for more information).
+    2. The type feat MUST be used when a commit adds a new feature to your application or library.
+    3. The type fix MUST be used when a commit represents a bug fix for your application.
+    4. A scope MAY be provided after a type. A scope MUST consist of a noun describing a section of the codebase surrounded by parenthesis, e.g., fix(parser):
+    5. A description MUST immediately follow the colon and space after the type/scope prefix. The description is a short summary of the code changes, e.g., fix: array parsing issue when multiple spaces were contained in string.
+    6. A longer commit body MAY be provided after the short description, providing additional contextual information about the code changes. The body MUST begin one blank line after the description.
+    7. A commit body is free-form and MAY consist of any number of newline separated paragraphs.
+    8. One or more footers MAY be provided one blank line after the body. Each footer MUST consist of a word token, followed by a :<space> separator, followed by a string value (this is inspired by the git trailer convention). See #allowed-footers for more information.
+    9. A footer’s token MUST use - in place of whitespace characters, e.g., Acked-by (this helps differentiate the footer section from a multi-paragraph body). An exception is made for BREAKING CHANGE, which MAY also be used as a token.
+    10. A footer’s value MAY contain spaces and newlines, and parsing MUST terminate when the next valid footer token/separator pair is observed.
+    11. Breaking changes MUST be indicated in the footer.
+    12. A breaking change MUST consist of the uppercase text BREAKING CHANGE, followed by a colon, space, and description, e.g., BREAKING CHANGE: environment variables now take precedence over config files.
+    13. Types other than feat and fix MAY be used in your commit messages, e.g., docs: updated ref docs (See #allowed-types for more information).
+    14. BREAKING-CHANGE MUST be synonymous with BREAKING CHANGE, when used as a token in a footer.
+    15. A feat, fix or a BREAKING CHANGE must have a Ticket, and a Changelog in the footer. The allowed values for the Changelog is either freeform text, `Title`, `Commit`, or `None`. The allowed value for `Ticket` is a valid ticket reference or `None`.
+    16. All commits must be signed off.
+
+## Notes
+
+Our grammar is taken from https://conventionalcommits.org with a few
+notable modifications.
+
+1. We do not support the exclamation mark in the commit header for breaking
+   changes.
+
+
+   Hence, a breaking change is done like:
+
+```
+feat(backend): Remove the v1 API
+
+...
+...
+
+BREAKING CHANGE: Removed the v1 API from the backend
+
+...
+...
+
+```
+
+   As opposed to:
+
+```
+feat(backend)!: Remove the v1 API
+
+...
+...
+
+```
+
+2. A fix, feat, or BREAKING CHANGE requires both a Changelog, and a Ticket
+   reference in the footer.
+
+```
+fix(changelog-generator): Remove brackets surrounding a ticket ref
+
+...
+...
+
+Changelog: None
+Ticket: MEN-5143
+Signed-off-by: Ole Petter <ole.orhagen@northern.tech>
+
+```
+
+In any instance, both the Changelog, and/or the Ticket can be None.
+
+3. All commits need to be signed off
+
+
+## Changelog tags
+
+Every commit requires a changelog tag to document what has changed from one
+release to the next. Unlike commit messages, these should be written in a user
+centric way.
+
+### Changelog tag types
+
+Below is the complete list of possible tags. See also examples in the next
+section.
+
+* `Changelog: <message>` - Use `<message>` as the changelog entry. Message can
+  span multiple lines, but is terminated by two consecutive newlines.
+
+* `Changelog: Title` - Use the commit title (the first line) as the changelog
+  entry.
+
+* `Changelog: Commit` - Use the entire commit message as a changelog entry (but
+  see filtered content below).
+
+* `Changelog: None` - Don't generate a changelog entry for this commit.
+
+A few things are always filtered from changelog entries: `cherry picked from...`
+lines and `Signed-off-by:`, which are standard Git strings. In addition, any
+reverted commit will automatically remove the corresponding entry from the
+changelog output.
+
+One commit can have several changelog tags, which will generate several entries,
+if desired.
+
+#### Examples:
+
+* Given the commit message:
+
+  ```
+  Fix crash when /etc/mender/mender.conf is empty.
+  ```
+
+  This message is understandable by a user, and can therefore be used as is:
+
+  ```
+  Fix crash when /etc/mender/mender.conf is empty.
+
+  Changelog: Title
+  ```
+
+* However, given the commit message:
+  ```
+  Implement mutex locking around user data.
+  ```
+
+  This is very developer centric and doesn't tell the user what changed for
+  him. In this case it's appropriate to give a different changelog message, like
+  this:
+
+  ```
+  Implement mutex locking around user data.
+
+  Changelog: Fix crash when updating user data fields.
+  ```
+
+* In some cases it's appropriate not to provide a changelog message, for
+  instance:
+
+  ```
+  Refactor dataProcess(), no functionality change.
+  ```
+
+  This is has no visible effect, therefore it's appropriate to add:
+
+  ```
+  Refactor dataProcess(), no functionality change.
+
+  Changelog: None
+  ```
+
+
+# allowed types
+
+The allowed commit types are as follows:
+
+* feat: A new feature
+* fix: A bug fix
+* chore - misc category, say comment nitpicks, spelling, etc.
+* build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
+* ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
+* docs: Documentation only changes
+* perf: A code change that improves performance
+* refactor: A code change that neither fixes a bug nor adds a feature
+* style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+* test: Adding missing tests or correcting existing tests
+
+
+# allowed footers
+
+In general our allowed footers are free-form key-values, with a few rules enforced in certain
+cases for keywords we own, see rule number `15` for more information.
+
+One notable addition is our Changelog tags, which can be overridden with a
+scope. The use case here is in the instance you find it hard to split a commit
+up, and it contains both a `fix`, and `feat` for instance. In this case, the
+`Changelog` key should look like:
+
+```
+Changelog(fix): <some description of the fix for the Changelog>
+Changelog(feat): <some description of the feature for the Changelog.
+```
+
+Which will add the individual entries to both entries in the Changelog.

--- a/commitlint/testcommitlint.sh
+++ b/commitlint/testcommitlint.sh
@@ -1,0 +1,324 @@
+#! /bin/bash
+
+function commitlint() {
+    $(dirname ${BASH_SOURCE[1]})/commitlint
+}
+
+function assert() {
+    case $1 in
+        true)
+            shift
+            local -r test_name="$1"
+            shift
+            if ! echo "$@" | commitlint; then
+                echo >&2 "== Failed == ${test_name}"
+                exit 1
+            else
+                echo >&2 "== Passed == ${test_name}"
+            fi
+            ;;
+        false)
+            shift
+            local -r test_name="$1"
+            shift
+            if echo "$@" | commitlint; then
+                echo >&2 "== Failed == ${test_name}"
+                exit 1
+            else
+                echo >&2 "== Passed == ${test_name}"
+            fi
+            ;;
+        *)
+            ;;
+    esac
+}
+
+
+assert "true" \
+       "Base case" \
+"chore(client): foobar"
+
+assert "true" \
+       "Base case (no scope)" \
+       "chore: foobar"
+
+assert "true" \
+       "Changelog required when fix, or feat or breaking change!" \
+"fix(client): foobar
+
+Ticket: None
+Changelog: None
+"
+
+assert "false" \
+       "Ticket required when fix, or feat or breaking change!" \
+"fix: foobar
+
+Changelog: None
+"
+
+assert "false" \
+       "fix requires a ticket" \
+       "fix(client): foobar
+
+Changelog: None
+"
+
+assert "false" \
+       "fix requires a Changelog" \
+       "fix(client): foobar
+
+Ticket: None
+"
+
+
+assert "false" \
+       "feat requires a Changelog" \
+       "feat: foobar
+
+Ticket: None
+"
+
+
+assert "true" \
+       "Multiple paragraphs in the body" \
+       "fix(client): foobar
+
+Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Donec hendrerit tempor
+tellus. Donec pretium posuere tellus. Proin quam nisl, tincidunt et, mattis
+eget, convallis nec, purus. Cum sociis natoque penatibus et magnis dis
+parturient montes, nascetur ridiculus mus. Nulla posuere. Donec vitae dolor.
+Nullam tristique diam non turpis. Cras placerat accumsan nulla. Nullam rutrum.
+Nam vestibulum accumsan nisl.
+
+Lorem ipsum dolor sit amet, consectetuer adipiscing elit.  Donec hendrerit tempor tellus.  Donec pretium posuere tellus.  Proin quam nisl, tincidunt et, mattis eget, convallis nec, purus.  Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.  Nulla posuere.  Donec vitae dolor.  Nullam tristique diam non turpis.  Cras placerat accumsan nulla.  Nullam rutrum.  Nam vestibulum accumsan nisl.
+
+Ticket: None
+Changelog: None
+
+"
+
+assert "false" \
+       "Body must have one line of air in between the header and the body" \
+       "fix(client): foobar
+Lorem ipsum dolor sit amet, consectetuer adipiscing elit.  Donec hendrerit tempor tellus.  Donec pretium posuere tellus.  Proin quam nisl, tincidunt et, mattis eget, convallis nec, purus.  Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.  Nulla posuere.  Donec vitae dolor.  Nullam tristique diam non turpis.  Cras placerat accumsan nulla.  Nullam rutrum.  Nam vestibulum accumsan nisl.
+
+"
+
+assert "false" \
+       "Error fix misspelled as fx" \
+       "fx(client): foobar
+
+"
+
+assert "false" \
+       "BREAKING CHANGE requires a Changelog and a ticket" \
+       "feat(client): foobar
+
+BREAKING CHANGE: No more bueno
+"
+
+assert "true" \
+       "BREAKING CHANGE requires a Changelog and a Ticket" \
+       "chore(client): foobar
+
+Ticket: None
+Changelog: None
+
+BREAKING CHANGE: No more bueno
+"
+
+
+assert "true" \
+       "Chore handling lorem ipsum etc etc" \
+       "chore(client): foobar
+
+
+Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Donec hendrerit tempor
+tellus. Donec pretium posuere tellus. Proin quam nisl, tincidunt et, mattis
+eget, convallis nec, purus. Cum sociis natoque penatibus et magnis dis
+parturient montes, nascetur ridiculus mus. Nulla posuere. Donec vitae dolor.
+Nullam tristique diam non turpis. Cras placerat accumsan nulla. Nullam rutrum.
+Nam vestibulum accumsan nisl.
+
+
+Lorem ipsum dolor sit amet, consectetuer adipiscing elit.  Donec hendrerit tempor tellus.  Donec pretium posuere tellus.  Proin quam nisl, tincidunt et, mattis eget, convallis nec, purus.  Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.  Nulla posuere.  Donec vitae dolor.  Nullam tristique diam non turpis.  Cras placerat accumsan nulla.  Nullam rutrum.  Nam vestibulum accumsan nisl.
+
+
+"
+
+
+assert "false" \
+       "No air in between body and footer" \
+       "fix(client): foobar
+
+
+Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Donec hendrerit tempor
+tellus. Donec pretium posuere tellus. Proin quam nisl, tincidunt et, mattis
+eget, convallis nec, purus. Cum sociis natoque penatibus et magnis dis
+parturient montes, nascetur ridiculus mus. Nulla posuere. Donec vitae dolor.
+Nullam tristique diam non turpis. Cras placerat accumsan nulla. Nullam rutrum.
+Nam vestibulum accumsan nisl.
+Ticket: None
+Changelog: None
+
+BREAKING CHANGE: No more bueno
+"
+
+assert "true" \
+       "Changelog commit" \
+       "fix(client): foobar
+
+Changelog: Commit
+Ticket: None
+"
+
+assert "true" \
+       "Multiline Changelog commit" \
+       "fix(client): foobar
+
+Changelog: Lorem ipsum dolor sit amet, consectetuer adipiscing elit.  Donec hendrerit tempor tellus.  Donec pretium posuere tellus.  Proin quam nisl, tincidunt et, mattis eget, convallis nec, purus.  Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.  Nulla posuere.  Donec vitae dolor.  Nullam tristique diam non turpis.  Cras placerat accumsan nulla.  Nullam rutrum.  Nam vestibulum accumsan nisl.
+Ticket: None
+
+"
+
+assert "true" \
+       "With sign-off" \
+       "fix(client): foobar
+
+Changelog: Lorem ipsum dolor sit amet, consectetuer adipiscing elit.  Donec hendrerit tempor tellus.  Donec pretium posuere tellus.  Proin quam nisl, tincidunt et, mattis eget, convallis nec, purus.  Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.  Nulla posuere.  Donec vitae dolor.  Nullam tristique diam non turpis.  Cras placerat accumsan nulla.  Nullam rutrum.  Nam vestibulum accumsan nisl.
+Ticket: None
+Signed-off-by: Ole Petter <ole.orhagen@northern.tech>
+"
+
+assert "true" \
+       "real commit check" \
+"fix(changelog-generator): Remove brackets surrounding a ticket ref
+
+Previously a ticket reference embedded in brackets would leave:
+
+* [] Fix sending on closed signal channel
+    ([MEN-4832](https://tracker.mender.io/browse/MEN-4832))
+
+After this fix:
+
+* Fix sending on closed signal channel
+    ([MEN-4832](https://tracker.mender.io/browse/MEN-4832))
+
+Changelog: None
+Ticket: MEN-5143
+Signed-off-by: Ole Petter <ole.orhagen@northern.tech>
+"
+
+assert "true" \
+       "Ticket allowed in all cases" \
+       "chore(changelog-generator): Remove brackets surrounding a ticket ref
+
+Previously a ticket reference embedded in brackets would leave:
+
+* [] Fix sending on closed signal channel
+    ([MEN-4832](https://tracker.mender.io/browse/MEN-4832))
+
+After this fix:
+
+* Fix sending on closed signal channel
+    ([MEN-4832](https://tracker.mender.io/browse/MEN-4832))
+
+Ticket: MEN-5143
+Signed-off-by: Ole Petter <ole.orhagen@northern.tech>
+"
+
+
+assert "false" \
+       "BREAKING CHANGE vs BREAKING-CHANGE (this should fail due to missing Changelog)" \
+       "chore(client): foobar
+
+Changelog: None
+
+BREAKING-CHANGE: No more bueno
+"
+
+
+assert "true" \
+       "fix with cherry-pick footer" \
+       "fix(client): foobar
+
+Changelog: None
+Ticket: None
+
+Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
+(cherry picked from commit 9ce8090ec2e4c7dc4a6ad428751a761254520106)
+"
+
+assert "false" \
+       "Misspelled Title in the Changelog" \
+       "fix(client): foobar
+
+Changelog: Tilte
+Ticket: None
+
+Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
+(cherry picked from commit 9ce8090ec2e4c7dc4a6ad428751a761254520106)
+"
+
+assert "true" \
+       "Changelog with scope" \
+       "fix(client): foobar
+
+Changelog(fix): Title
+Ticket: None
+
+Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
+(cherry picked from commit 9ce8090ec2e4c7dc4a6ad428751a761254520106)
+"
+
+
+assert "true" \
+       "Changelog(s) with scope(s)" \
+       "fix(client): foobar
+
+Changelog(fix): Title
+Changelog(feat): Lorem Ipsum Dorem.
+Ticket: None
+
+Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
+(cherry picked from commit 9ce8090ec2e4c7dc4a6ad428751a761254520106)
+"
+
+
+assert "false" \
+       "Changelog(s) with scope(s), misspelled Changelog" \
+       "fix(client): foobar
+
+Changelog(feat): Lorem Ipsum Dorem.
+Changelog(fix): Tilte
+Ticket: None
+
+Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
+(cherry picked from commit 9ce8090ec2e4c7dc4a6ad428751a761254520106)
+"
+
+assert "false" \
+       "Misspelled Ticket: Noen" \
+       "fix(client): foobar
+
+Changelog(feat): Lorem Ipsum Dorem.
+Changelog(fix): Title
+Ticket: Noen
+
+Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
+(cherry picked from commit 9ce8090ec2e4c7dc4a6ad428751a761254520106)
+"
+
+assert "true" \
+       "Proper ticket number" \
+       "fix(client): foobar
+
+Changelog: Title
+Ticket: MEN-1234
+
+Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
+(cherry picked from commit 9ce8090ec2e4c7dc4a6ad428751a761254520106)
+"
+
+exit 0


### PR DESCRIPTION
This adds a conventional commits checker written in `AWK`, which checks the format of our commits through the regualar `check-commits` script.

