### PR TITLE
chore: made binary extraction no longer rely on a shell

### DIFF
--- a/.gitlab-ci-check-docker-acceptance.yml
+++ b/.gitlab-ci-check-docker-acceptance.yml
@@ -50,7 +50,9 @@ test:prepare_acceptance:
     - docker build -f Dockerfile.acceptance-testing -t $DOCKER_REPOSITORY:prtest .
     - docker save $DOCKER_REPOSITORY:prtest > tests_image.tar
     - docker build -t $DOCKER_REPOSITORY:pr .
-    - docker run --rm --entrypoint "/bin/sh" -v $(pwd):/binary $DOCKER_REPOSITORY:pr -c "cp /usr/bin/${CI_PROJECT_NAME} /binary"
+    - CONTAINER_ID=$(docker create "$DOCKER_REPOSITORY:pr")
+    - docker cp "$CONTAINER_ID:/usr/bin/${CI_PROJECT_NAME}" "$(pwd)"
+    - docker rm "$CONTAINER_ID"
     # Repos using common tester image might not have the Dockerfile
     - if [ -f tests/Dockerfile ]; then
     -   docker build -t testing -f tests/Dockerfile tests

--- a/licenses.go
+++ b/licenses.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.


### PR DESCRIPTION
- this is to also support extracting files from scratch based images
Changelog: None

Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>