### PR TITLE
fix: the commitlint parser had a lookahead bug for no body commits

### DIFF
--- a/commitlint/commitlint
+++ b/commitlint/commitlint
@@ -255,7 +255,7 @@ function parse() {
     #
     # BODY (optional)
     #
-    if (! tok != EOF && ! is_footer(next_tok)) {
+    if ( ! tok != EOF && ! is_footer(tok) && ! is_footer(next_tok) ) {
 
         # BODY
         parse_body()

--- a/commitlint/testcommitlint.sh
+++ b/commitlint/testcommitlint.sh
@@ -321,4 +321,13 @@ Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
 (cherry picked from commit 9ce8090ec2e4c7dc4a6ad428751a761254520106)
 "
 
+assert "false" \
+       "No Ticket in the body" \
+       "feat: extend deployments instruction with artifact id
+
+Changelog: Title
+
+Signed-off-by: Krzysztof Jaskiewicz <krzysztof.jaskiewicz@northern.tech>
+"
+
 exit 0


### PR DESCRIPTION
This worked on all other commits, as they had both a Ticket and a Changelog footer.

Without this, the error message spit out was wrong, in that the Changelog was missing.

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>