### PR TITLE
fix(commitlint): allow lowercase footer keyword values

### DIFF
--- a/commitlint/commitlint
+++ b/commitlint/commitlint
@@ -324,7 +324,7 @@ function lint_required_footer_values() {
 function verify_changelog(changelog) {
     # Strip the CHANGELOG[(fix|feat)] prefix
     gsub(CHANGELOG_PREFIX, "", changelog)
-    if ( match(changelog, "(None|Title|Commit|All|\\S+(\\s+\\S+){2,})") == 0 ) {
+    if ( match(changelog, "([Nn]one|[Tt]itle|[Cc]ommit|[Aa]ll|\\S+(\\s+\\S+){2,})") == 0 ) {
         error("Misspelled word in Changelog")
     }
 }

--- a/commitlint/testcommitlint.sh
+++ b/commitlint/testcommitlint.sh
@@ -369,4 +369,15 @@ Ticket: MEN-1234
 Signed-off-by: Krzysztof Jaskiewicz <krzysztof.jaskiewicz@northern.tech>
 "
 
+
+assert "false" \
+       "Allow lowercase keyword values" \
+       "feat: extend deployments instruction with artifact id
+
+Changelog: title
+Ticket: none
+
+Signed-off-by: Krzysztof Jaskiewicz <krzysztof.jaskiewicz@northern.tech>
+"
+
 exit 0


### PR DESCRIPTION
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>