### PR TITLE
docs(commitlint): typo in the grammar specification for refactor

### DIFF
--- a/commitlint/grammar.md
+++ b/commitlint/grammar.md
@@ -169,7 +169,7 @@ The allowed commit types are as follows:
 * ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
 * docs: Documentation only changes
 * perf: A code change that improves performance
-* refactor: A code change that neither fixes a bug nor adds a feature
+* refac: A code change that neither fixes a bug nor adds a feature
 * style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
 * test: Adding missing tests or correcting existing tests
 


### PR DESCRIPTION
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>