### PR TITLE
chore: Show both stdout and stderr in shasum checks

### DIFF
--- a/check_license.sh
+++ b/check_license.sh
@@ -61,10 +61,8 @@ sed '/^$/d' $CHKSUM_FILE > $TMP_CHKSUM_FILE
 # Use the tmp-file for the rest of the script
 CHKSUM_FILE=$TMP_CHKSUM_FILE
 
-# Collect only stderr from the subcommand
 output="$(
-          exec 3>&1
-          shasum --warn --algorithm 256 --check $CHKSUM_FILE > /dev/null 2>&3
+          shasum --warn --algorithm 256 --check $CHKSUM_FILE
 )"
 
 if echo "$output" | grep -q 'line is improperly formatted' -; then


### PR DESCRIPTION
chore: Show both stdout and stderr in shasum checks

Changelog: None
Ticket: None
Signed-off-by: Maciej Tomczuk <maciej.tomczuk@northern.tech>