### PR TITLE
feat: call the rerun_build endpoint to finalize the coverage report

### DIFF
--- a/.gitlab-ci-check-docker-acceptance.yml
+++ b/.gitlab-ci-check-docker-acceptance.yml
@@ -158,6 +158,8 @@ coveralls:finish-build:
   # See https://docs.coveralls.io/parallel-build-webhook
   variables:
     COVERALLS_WEBHOOK_URL: "https://coveralls.io/webhook"
+    COVERALLS_RERUN_BUILD_URL: "https://coveralls.io/rerun_build"
   image: appropriate/curl
   script:
     - 'curl -k ${COVERALLS_WEBHOOK_URL}?repo_token=${COVERALLS_TOKEN} -d "payload[build_num]=$CI_PIPELINE_ID&payload[status]=done"'
+    - 'curl -k "${COVERALLS_RERUN_BUILD_URL}?repo_token=${COVERALLS_TOKEN}&build_num=${CI_PIPELINE_ID}"'


### PR DESCRIPTION
Coveralls.io implemented a new end-point (Rerun Build Webhook) to trigger a rebuild of the coverage report when multiple builds are in use.  Without a call to this end-point, the aggregated coverage report for builds could miss data from one of the builds, leading to an erroneous drop in coverage which can cause a failed check on GitHub.

Changelog: None
Ticket: None

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>