### PR TITLE
fix(check_commits.sh): Use "range notation" for git rev-parse command

### DIFF
--- a/.gitlab-ci-check-commits-signoffs.yml
+++ b/.gitlab-ci-check-commits-signoffs.yml
@@ -22,7 +22,7 @@ test:check-commits:
     - git fetch origin 'refs/heads/*:refs/heads/*'
     # Get last remaining tags, if any.
     - git fetch --tags origin
-    - git clone --depth=1 http://github.com/mendersoftware/mendertesting /tmp/mendertesting
+    - git clone --depth=1 https://github.com/mendersoftware/mendertesting /tmp/mendertesting
   script:
     # Verify that the commits have signoffs.
     - /tmp/mendertesting/check_commits.sh --signoffs

--- a/.gitlab-ci-check-commits.yml
+++ b/.gitlab-ci-check-commits.yml
@@ -25,7 +25,7 @@ test:check-commits:
     - if [ "${CI_PROJECT_NAME}" = "mendertesting" ]; then
     -   git clone --shared --local . /tmp/mendertesting
     - else
-    -   git clone --depth=1 http://github.com/mendersoftware/mendertesting /tmp/mendertesting
+    -   git clone --depth=1 https://github.com/mendersoftware/mendertesting /tmp/mendertesting
     - fi
   script:
     # Check commit compliance.

--- a/.gitlab-ci-check-license.yml
+++ b/.gitlab-ci-check-license.yml
@@ -50,7 +50,7 @@ test:check-license:
     - if [ "$CI_PROJECT_NAME" = "mendertesting" ]; then
     -   SCRIPT_PATH=$PWD
     - else
-    -   git clone --depth=1 http://github.com/mendersoftware/mendertesting /tmp/mendertesting
+    -   git clone --depth=1 https://github.com/mendersoftware/mendertesting /tmp/mendertesting
     -   SCRIPT_PATH=/tmp/mendertesting
     - fi
   script:

--- a/.gitlab-ci-check-python3-format.yml
+++ b/.gitlab-ci-check-python3-format.yml
@@ -67,7 +67,7 @@ test:check-python3-formatting:
     - git fetch origin 'refs/heads/*:refs/heads/*'
     # Get last remaining tags, if any.
     - git fetch --tags origin
-    - git clone --depth=1 http://github.com/mendersoftware/mendertesting /tmp/mendertesting
+    - git clone --depth=1 https://github.com/mendersoftware/mendertesting /tmp/mendertesting
   script:
     # Check that the Python code is correctly formatted
     - env /tmp/mendertesting/check_python_code_format

--- a/check_commits.sh
+++ b/check_commits.sh
@@ -137,11 +137,11 @@ function check_commit_for_signoffs() {
 
 }
 
-# If any commit in the range TARGET_BRANCH...{hosted,staging} matches a commit in the PR
+# If any commit in the range TARGET_BRANCH..{hosted,staging} matches a commit in the PR
 function prevent_staging_and_hosted_leaks() {
     local -r pull_request_commit="$1"
-    # Get the commits in the range TARGET_BRANCH...{hosted,staging}
-    local -r target_branch_commits="$(git rev-list origin/${TARGET_BRANCH}...origin/hosted 2>/dev/null || git rev-list origin/${TARGET_BRANCH}...origin/staging)"
+    # Get the commits in the range TARGET_BRANCH..{hosted,staging}
+    local -r target_branch_commits="$(git rev-list origin/${TARGET_BRANCH}..origin/hosted 2>/dev/null || git rev-list origin/${TARGET_BRANCH}..origin/staging)"
     for commit in ${target_branch_commits}; do
         if [[ "${commit}" = "${pull_request_commit}" ]]; then
             echo >&2 "The commit ${pull_request_commit} is present in the hosted or staging branch."


### PR DESCRIPTION
Instead of "symmetric difference notation".
    
The list of commits that we should prevent from leaking are all the
commits from staging/hosted branches that are not in the target branch
(aka range), but we should ignore other commits that are already in the
target branch (aka symmetric difference).
    
See: https://git-scm.com/docs/git-rev-parse#_dotted_range_notations