### PR TITLE
Fix bug with multiple multiline changelogs. 

### DIFF
--- a/commitlint/commitlint
+++ b/commitlint/commitlint
@@ -292,6 +292,7 @@ function parse_footer() {
                 # Require empty line afterwards in paragraph
                 advance()
                 empty_line("A 'Changelog' over multiple lines needs to have a trailing empty line")
+                continue
             }
         }
         if (match(tok, TICKET)) {

--- a/commitlint/commitlint
+++ b/commitlint/commitlint
@@ -83,6 +83,8 @@ function advance() {
     tok_type = next_tok_type
     next_tok = _tok
     next_tok_type = _tok_type
+    debugf("Current token: %s", tok)
+    debugf("Next token: %s", next_tok)
 }
 
 function _advance() {

--- a/commitlint/commitlint
+++ b/commitlint/commitlint
@@ -158,21 +158,21 @@ function _advance() {
         return _tok
     }
     if (match(line, WORD)) {
-           _tok = substr(line, 1, RLENGTH)
-            debugf("Matched LINE: %s", _tok)
-            VAL = _tok
-            line = ""
-            _tok_type = "WORD"
-            return _tok
+        _tok = substr(line, 1, RLENGTH)
+         debugf("Matched LINE: %s", _tok)
+         VAL = _tok
+         line = ""
+         _tok_type = "WORD"
+         return _tok
     }
     if (match(line, EMPTY_LINE)) {
-            _tok = line
-            debugf("Matched EMPTY_LINE: %s", _tok)
-            VAL = _tok
-            line = ""
-            _tok_type = "EMPTY_LINE"
-            return _tok
-        }
+         _tok = line
+         debugf("Matched EMPTY_LINE: %s", _tok)
+         VAL = _tok
+         line = ""
+         _tok_type = "EMPTY_LINE"
+         return _tok
+    }
     if (match(line, LINE)) {
         _tok = line
         debugf("Matched LINE: %s", _tok)

--- a/commitlint/testcommitlint.sh
+++ b/commitlint/testcommitlint.sh
@@ -425,5 +425,20 @@ Ticket: MEN-1234
 Signed-off-by: Signed-off-by: Lluis Campos <lluis.campos@northern.tech>"
 
 
+assert "true" \
+       "Commit with multiple multiline Changelogs" \
+       "fix: Commit with multiple multiline Changelogs
+
+Ticket: None
+
+Changelog: First multiline changelog
+with multiple words
+
+Changelog: First multiline changelog with one
+word
+
+Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>"
+
+
 
 exit 0


### PR DESCRIPTION
```
commit 4410811b89749ab1c1f17f25bbe8ace919baf8e0
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Mon Oct 3 11:42:44 2022

    fix(commitlint): Fix bug with multiple multiline changelogs.
    
    The `empty_line` function already advances, so we should not advance
    again at the end of the loop, or we end up skipping a token.
    
    Changelog: None
    Ticket: None
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit 045a2d771301ee4e098ee16233d360caee435e11
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Mon Oct 3 11:41:05 2022

    chore(commitlint): Add clearer current/next token debug logging.
    
    It's a bit confusing without it because the "Matched" log entries
    refer to the next token, not the current one.
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit 944ae2557a7dc3cf6087c61d1abf065ffbcea05e
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Mon Oct 3 11:21:49 2022

    chore: Fix indentation.
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
```