### PR TITLE
fix: Make commit tags case insensitive.

### DIFF
--- a/commitlint/commitlint
+++ b/commitlint/commitlint
@@ -23,18 +23,20 @@ BEGIN {
     EMPTY_LINE = "^$"
 
     ## Footer
-    CHANGELOG_PREFIX="Changelog(\\((fix|feat)+\\))?: "
+    CHANGELOG_PREFIX="^Changelog(\\((fix|feat)+\\))?: "
     CHANGELOG=CHANGELOG_PREFIX ".*"
     TICKET="Ticket: .*"
     BREAKING_CHANGE="BREAKING[- ]CHANGE: .*"
     SIGN_OFF_LINE="Signed-off-by: .*"
     CHERRY_PICK="(cherry picked from commit .*)"
-    CANCEL_CHANGELOG="Cancel-[Cc]hangelog: *([0-9a-f]+).*"
+    CANCEL_CHANGELOG="Cancel-changelog: *([0-9a-f]+).*"
 
     ## special
     COLON = "^:"
     SINGLE_SPACE = "^ {1}"
     EOF = "E_O_F"
+
+    IGNORECASE = 1
 
     # Initialize the lexer
     init_lexer()

--- a/commitlint/testcommitlint.sh
+++ b/commitlint/testcommitlint.sh
@@ -440,5 +440,16 @@ word
 Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>"
 
 
+assert "true" \
+       "Commit with lowercase entries" \
+       "fix: Commit with lowercase entries
+
+Ticket: none
+
+Changelog: none
+
+Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>"
+
+
 
 exit 0


### PR DESCRIPTION
There is no reason for them to be case sensitive, and it's confusing for contributors. Also, several old commits already carry tags like these.

Note the added line-beginning anchor in the regex. This was always wrong because it would match "Cancel-changelog" as well, but because the test used a lowercase "c", it wasn't caught until we switched it to be case insensitive.

Changelog: none
Ticket: none

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>