### PR TITLE
ci: Fix artifacts default path for build image

### DIFF
--- a/.gitlab-ci-check-docker-build.yml
+++ b/.gitlab-ci-check-docker-build.yml
@@ -93,7 +93,8 @@ build:docker:
   artifacts:
     expire_in: 2w
     paths:
-      - ${IMAGE_ARTIFACT_FILENAME:-${CI_PROJECT_DIR}/image.tar}
+      - ${IMAGE_ARTIFACT_FILENAME}
+      - image.tar
 
 publish:image:
   stage: publish


### PR DESCRIPTION
It seems like env variables in `artifacts` do not expand using bash syntax and the default path is evaluating to `/image.tar`.

Duplicate the paths instead, which will issue a warning on missing one of the two paths but that is acceptable.