### PR TITLE
fix: Put C++ access modifiers on same level as parent class.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -25,6 +25,8 @@ BinPackParameters: false
 AlignAfterOpenBracket: AlwaysBreak
 AllowAllParametersOfDeclarationOnNextLine: true
 IndentCaseLabels: false
+IndentAccessModifiers: false
+AccessModifierOffset: -4
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortIfStatementsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: None


### PR DESCRIPTION
I don't quite understand why the -4 is necessary. According to the `IndentAccessModifiers` docs [1] it should already do it correctly when it is set to false. The Google style has an
`AccessModifierOffset` default of -1, but this still doesn't explain the behavior.

This fixes a mixed-tabs-and-spaces issue with access modifiers.

[1] https://clang.llvm.org/docs/ClangFormatStyleOptions.html

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>