### PR TITLE
chore: Tweak clang-format constructor initializers indent setting.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -33,4 +33,5 @@ AllowShortFunctionsOnASingleLine: None
 BreakBeforeBraces: Attach
 BreakBeforeBinaryOperators: NonAssignment
 InsertBraces: true
+BreakConstructorInitializers: AfterColon
 ---


### PR DESCRIPTION
Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>