### PR TITLE
fix: Avoid reusing (shallow) workspace for git test jobs

### DIFF
--- a/.gitlab-ci-check-commits-signoffs.yml
+++ b/.gitlab-ci-check-commits-signoffs.yml
@@ -11,7 +11,8 @@ test:check-commits:
     - /^(master|hosted|staging|production|saas-v[0-9.]+|[0-9]+\.[0-9]+\.x)$/
   image: alpine
   variables:
-    GIT_DEPTH: 0
+    GIT_STRATEGY: clone # clone entire repo instead of reusing workspace
+    GIT_DEPTH: 0 # avoid shallow clone, this test requires full git history
   before_script:
     # Install dependencies
     - apk add --no-cache git bash

--- a/.gitlab-ci-check-commits.yml
+++ b/.gitlab-ci-check-commits.yml
@@ -11,7 +11,8 @@ test:check-commits:
     - /^(master|hosted|staging|production|saas-v[0-9.]+|[0-9]+\.[0-9]+\.x|[0-9]+\.[0-9]+\.[0-9]+)$/
   image: alpine
   variables:
-    GIT_DEPTH: 0
+    GIT_STRATEGY: clone # clone entire repo instead of reusing workspace
+    GIT_DEPTH: 0 # avoid shallow clone, this test requires full git history
   before_script:
     # Install dependencies
     - apk add --no-cache git bash gawk

--- a/.gitlab-ci-check-golang-unittests.yml
+++ b/.gitlab-ci-check-golang-unittests.yml
@@ -45,7 +45,8 @@ test:unit:
   services:
     - mongo:4.4
   variables:
-    GIT_DEPTH: 0
+    GIT_STRATEGY: clone # clone entire repo instead of reusing workspace
+    GIT_DEPTH: 0 # avoid shallow clone, this test requires full git history
     MONGODB_DEBIAN_RELEASE: "buster"
     MONGODB_VERSION: "4.4"
   before_script:

--- a/.gitlab-ci-check-license.yml
+++ b/.gitlab-ci-check-license.yml
@@ -36,7 +36,8 @@ test:check-license:
   needs: []
   image: alpine
   variables:
-    GIT_DEPTH: 0
+    GIT_STRATEGY: clone # clone entire repo instead of reusing workspace
+    GIT_DEPTH: 0 # avoid shallow clone, this test requires full git history
   before_script:
     # Install dependencies
     - apk add --no-cache git bash perl-utils


### PR DESCRIPTION
By explicitly defining `GIT_STRATEGY: clone`.

We have a set of tests that require a full clone of the repository, which was already using `GIT_DEPTH: 0` to disallow shallow clone.

However according to GitLab documentation [1], the job might still do a `fetch` instead of `clone` when it can reuse the workspace from a previous job. So if the previous job of the runner was one with a shallow clone (unit tests, format check) then the new job that requires full clone will fail.

My theory is that we have not seen it before because while using public runners it was very unlikely to happen that we _could_ reuse the workspace. Now, with our private runners, this will happen rather often.

See issue reported in GitLab [2] and the recommended workaround [3].

* [1] https://docs.gitlab.com/ee/ci/runners/configure_runners.html#git-strategy
* [2] https://gitlab.com/gitlab-org/gitlab/-/issues/350100
* [3] https://gitlab.com/gitlab-org/gitlab/-/issues/350100#note_899531082

Changelog: None
Ticket: QA-527