### PR TITLE
ci: Fix artifact recollection in docker build template

### DIFF
--- a/.gitlab-ci-check-docker-build.yml
+++ b/.gitlab-ci-check-docker-build.yml
@@ -91,8 +91,7 @@ build:docker:
   artifacts:
     expire_in: 2w
     paths:
-      - ${IMAGE_ARTIFACT_FILENAME}
-      - image.tar
+      - ${IMAGE_ARTIFACT_FILENAME:-image.tar}
 
 publish:image:
   tags:


### PR DESCRIPTION
Amends commit 02c6ffa5.

For some reason for jobs where this variable is undefined it is now resolving to `.`, which makes the job collect all workspace (the git repo) issuing warnings along the way.

Message from CI follows:
```
Uploading artifacts...
.: found 2882 matching artifact files and directories
image.tar: found 1 matching artifact files and directories
WARNING: Part of .git directory is on the list of files to archive
WARNING: This may introduce unexpected problems
```

This commit somewhat reverts 02c6ffa5 putting the artifact recollection to a one-liner but using a relative path.