### PR TITLE
Force branch update so it succeeds even when it pre-exists.

### DIFF
--- a/.gitlab-ci-check-commits-signoffs.yml
+++ b/.gitlab-ci-check-commits-signoffs.yml
@@ -22,7 +22,7 @@ test:check-commits:
     - git branch -m temp-branch || true
     # Git trick: Fetch directly into our local branches instead of remote
     # branches.
-    - git fetch origin 'refs/heads/*:refs/heads/*'
+    - git fetch -f origin 'refs/heads/*:refs/heads/*'
     # Get last remaining tags, if any.
     - git fetch --tags origin
     - git clone --depth=1 https://github.com/mendersoftware/mendertesting /tmp/mendertesting

--- a/.gitlab-ci-check-commits.yml
+++ b/.gitlab-ci-check-commits.yml
@@ -22,7 +22,7 @@ test:check-commits:
     - git branch -m temp-branch || true
     # Git trick: Fetch directly into our local branches instead of remote
     # branches.
-    - git fetch origin 'refs/heads/*:refs/heads/*'
+    - git fetch -f origin 'refs/heads/*:refs/heads/*'
     # Get last remaining tags, if any.
     - git fetch --tags origin
     - if [ "${CI_PROJECT_NAME}" = "mendertesting" ]; then

--- a/.gitlab-ci-check-golang-unittests.yml
+++ b/.gitlab-ci-check-golang-unittests.yml
@@ -73,7 +73,7 @@ test:unit:
     - git branch -m temp-branch || true
     # Git trick: Fetch directly into our local branches instead of remote
     # branches.
-    - git fetch origin 'refs/heads/*:refs/heads/*'
+    - git fetch -f origin 'refs/heads/*:refs/heads/*'
     # Get last remaining tags, if any.
     - git fetch --tags origin
 

--- a/.gitlab-ci-check-license.yml
+++ b/.gitlab-ci-check-license.yml
@@ -47,7 +47,7 @@ test:check-license:
     - git branch -m temp-branch || true
     # Git trick: Fetch directly into our local branches instead of remote
     # branches.
-    - git fetch origin 'refs/heads/*:refs/heads/*'
+    - git fetch -f origin 'refs/heads/*:refs/heads/*'
     # Get last remaining tags, if any.
     - git fetch --tags origin
     - if [ "$CI_PROJECT_NAME" = "mendertesting" ]; then

--- a/.gitlab-ci-check-python3-format.yml
+++ b/.gitlab-ci-check-python3-format.yml
@@ -66,7 +66,7 @@ test:check-python3-formatting:
     - git branch -m temp-branch || true
     # Git trick: Fetch directly into our local branches instead of remote
     # branches.
-    - git fetch origin 'refs/heads/*:refs/heads/*'
+    - git fetch -f origin 'refs/heads/*:refs/heads/*'
     # Get last remaining tags, if any.
     - git fetch --tags origin
     - git clone --depth=1 https://github.com/mendersoftware/mendertesting /tmp/mendertesting

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,7 @@ test:unit:
     - git branch -m temp-branch || true
     # Git trick: Fetch directly into our local branches instead of remote
     # branches.
-    - git fetch origin 'refs/heads/*:refs/heads/*'
+    - git fetch -f origin 'refs/heads/*:refs/heads/*'
     # Get last remaining tags, if any.
     - git fetch --tags origin
 


### PR DESCRIPTION
This is necessary when workers are reused. Since the repository, and its branches, may already be there locally, we have to force update them.