### PR TITLE
chore(clang-format): Break inheritance lists better.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -34,6 +34,7 @@ BreakBeforeBraces: Attach
 BreakBeforeBinaryOperators: NonAssignment
 InsertBraces: true
 BreakConstructorInitializers: AfterColon
+BreakInheritanceList: AfterColon
 PackConstructorInitializers: Never
 SpaceBeforeCpp11BracedList: true
 ---


### PR DESCRIPTION
By using a format that doesn't require knowing the tab width. This turns this:

```
class Stuff : public A,
              public B {
```

into:

```
class Stuff :
    public A,
    public B {
```