### PR TITLE
chore: API docs lint fix.

### DIFF
--- a/.gitlab-ci-check-apidocs.yml
+++ b/.gitlab-ci-check-apidocs.yml
@@ -51,11 +51,15 @@ test:validate-open-api:
     - mender-qa-worker-generic-light
   stage: test
   image:
-    name: stoplight/spectral
-    entrypoint: ['']
-  script: |
-    - echo "extends: ['spectral:oas']" > .spectral.yaml
-    - spectral lint -D -f junit -o spectral-report.xml docs/*.yml
+    name: alpine
+  before_script:
+    - apk --update add curl
+    - curl -L https://raw.github.com/stoplightio/spectral/master/scripts/install.sh -o install.sh
+    - sh install.sh
+  script:
+    - |
+      echo "extends: ['spectral:oas']" > .spectral.yaml
+    - spectral lint -v -D -f junit -o spectral-report.xml docs/*.yml
   allow_failure: true
   artifacts:
     when: always


### PR DESCRIPTION
api docs lint checks were not running due to:

WARNING: Entrypoint override disabled

and using the override itself.

* example of a job in master: https://gitlab.com/Northern.tech/Mender/deployments/-/jobs/4214764960
* see also, for running example of this patch: https://github.com/mendersoftware/deployments/pull/862

the problem with this fix: spectral lint returns 1 shall I add || true and if so, how to detect the failure?

Ticket: None