### PR TITLE
chore: moved errors on api spec parsing to the warning level

### DIFF
--- a/.gitlab-ci-check-apidocs.yml
+++ b/.gitlab-ci-check-apidocs.yml
@@ -58,7 +58,11 @@ test:validate-open-api:
     - sh install.sh
   script:
     - |
-      echo "extends: ['spectral:oas']" > .spectral.yaml
+      cat > .spectral.yaml << EOF
+      extends: [['spectral:oas', all]]
+      parserOptions:
+        incompatibleValues: 1
+      EOF
     - spectral lint -v -D -f junit -o spectral-report.xml docs/*.yml
   allow_failure: true
   artifacts:


### PR DESCRIPTION
this silences all the `Mapping key must be a string scalar rather than number` for the response definitions, there was a longer discussion [here](https://github.com/OAI/OpenAPI-Specification/issues/2171) which could serve as an argument to enforce strings there, but at this point I think it's better to first focus on other issues we have in the api specs

report example [here](https://gitlab.com/Northern.tech/Mender/inventory/-/pipelines/886844179/test_report)