### PR TITLE
golang unit test fix

### DIFF
--- a/.gitlab-ci-check-golang-unittests.yml
+++ b/.gitlab-ci-check-golang-unittests.yml
@@ -41,7 +41,7 @@ test:unit:
   needs: []
   except:
     - /^saas-[a-zA-Z0-9.]+$/
-  image: golang:1.20
+  image: golang:1.20.4
   services:
     - mongo:4.4
   variables:


### PR DESCRIPTION
in the golang unit tests pipeline temporarily switch from golang:1.20 to golang:1.20.4, because of issues with latest version of golang:1.20