### PR TITLE
ci(go/units): Add TEST_MONGO_URL to unit tests job template

### DIFF
--- a/.gitlab-ci-check-golang-unittests.yml
+++ b/.gitlab-ci-check-golang-unittests.yml
@@ -49,6 +49,7 @@ test:unit:
     GIT_DEPTH: 0 # avoid shallow clone, this test requires full git history
     MONGODB_DEBIAN_RELEASE: "buster"
     MONGODB_VERSION: "4.4"
+    TEST_MONGO_URL: "mongodb://mongo"
   before_script:
     # Install JUnit test reporting formatter
     - go install github.com/jstemmer/go-junit-report@v1.0.0


### PR DESCRIPTION
Allows us to update debian image once mendersoftware/go-lib-micro#201 is merged and pulled to all backend services.