### PR TITLE
ci: Allow to fail Mender specific jobs on build/publish template

### DIFF
--- a/.gitlab-ci-check-docker-build.yml
+++ b/.gitlab-ci-check-docker-build.yml
@@ -215,17 +215,19 @@ publish:image:mender:
     - *export_docker_vars
     - *get_release_tool_alpine
     - *docker_login_registries
+  allow_failure:
+    exit_codes: 137
   script:
     # If the repo is not recognized, ignore
     - if ! echo $(release_tool --list git --all) | grep $CI_PROJECT_NAME; then
     -  echo "Repository $CI_PROJECT_NAME not found in release_tool. Exiting"
-    -  exit 0
+    -  exit 137
     - fi
     # If the repo/branch is not part of a Mender release, also ignore
     - integration_versions=$(release_tool --integration-versions-including $CI_PROJECT_NAME --version $CI_COMMIT_REF_NAME | sed -e 's/origin\///')
     - if test -z "$integration_versions"; then
     -  echo "Repository $CI_PROJECT_NAME version $CI_COMMIT_REF_NAME is not part of any Mender release. Exiting"
-    -  exit 0
+    -  exit 137
     - fi
     # Load image
     - docker load -i ${IMAGE_ARTIFACT_FILENAME:-${CI_PROJECT_DIR}/image.tar}
@@ -260,17 +262,19 @@ publish:image-multiplatform:mender:
     - *export_docker_vars
     - *get_release_tool_alpine
     - *docker_login_registries
+  allow_failure:
+    exit_codes: 137
   script:
     # If the repo is not recognized, ignore
     - if ! echo $(release_tool --list git --all) | grep $CI_PROJECT_NAME; then
     -  echo "Repository $CI_PROJECT_NAME not found in release_tool. Exiting"
-    -  exit 0
+    -  exit 137
     - fi
     # If the repo/branch is not part of a Mender release, also ignore
     - integration_versions=$(release_tool --integration-versions-including $CI_PROJECT_NAME --version $CI_COMMIT_REF_NAME | sed -e 's/origin\///')
     - if test -z "$integration_versions"; then
     -  echo "Repository $CI_PROJECT_NAME version $CI_COMMIT_REF_NAME is not part of any Mender release. Exiting"
-    -  exit 0
+    -  exit 137
     - fi
     # Publish the image for all releases
     - for version in $integration_versions; do
@@ -293,11 +297,13 @@ trigger:saas:sync-staging-component:
     - *export_docker_vars
     - *get_release_tool_alpine
     - apk add --no-cache curl
+  allow_failure:
+    exit_codes: 137
   script:
     # If the repo is not recognized, ignore
     - if ! echo $(release_tool --list git --all) | grep $CI_PROJECT_NAME; then
     -  echo "Repository $CI_PROJECT_NAME not found in release_tool. Exiting"
-    -  exit 0
+    -  exit 137
     - fi
     # Trigger the sync once per container in this repo
     - for container in $(release_tool -m git ${CI_PROJECT_NAME} container); do


### PR DESCRIPTION
This template is used by many repositories that build and publish Docker images. For Mender specific images, there are extra jobs that deal with Mender specific use cases.

Ideally these jobs should be disabled (removed from the pipeline) but so far we were only early exiting leaving the job "green".

With this change we return an specific error code to fail the job while we allow for the whole pipeline to continue.

The motivation is to better visualize what the job has done (nothing) instead of visualizing it as just success (while doing nothing).