### PR TITLE
Multiplatform prod rolling update process

### DIFF
--- a/.gitlab-ci-check-docker-build.yml
+++ b/.gitlab-ci-check-docker-build.yml
@@ -126,8 +126,6 @@ build:docker-multiplatform:
   rules:
     - if: $MULTIPLATFORM_BUILD != "true"
       when: never
-    - if: '$CI_COMMIT_TAG =~ /^saas-[a-zA-Z0-9.]+$/'
-      when: never
     - when: on_success
   image: "registry.gitlab.com/northern.tech/mender/mender-test-containers:docker-multiplatform-buildx-v1-master"
   services:
@@ -183,7 +181,7 @@ publish:image-multiplatform:
   rules:
     - if: $MULTIPLATFORM_BUILD != "true"
       when: never
-    - if: '$CI_COMMIT_BRANCH =~ /^(master|staging|production|feature-.+)$/'
+    - if: '$CI_COMMIT_BRANCH =~ /^(main|master|staging|production|feature-.+|saas-[a-zA-Z0-9.]+)$/'
   image: "registry.gitlab.com/northern.tech/mender/mender-test-containers:docker-multiplatform-buildx-v1-master"
   services:
     - docker:20.10.21-dind


### PR DESCRIPTION
Ticket: QA-613

When a new production tag is issued:
* build and push the container image from the tag
* run the helm version bump for both staging and production.

* Why?
The job `trigger:alvaldi-helm-version-bump:staging` needs `publish:image-multiplatform` to finish successfully, while the original pipeline has just the `publish:image:saas` which is a re-tag of the `staging_commitsha` to `saas-v2023.....`

* Why I'm not simply creating creating a new `publish:image-multiplatform:saas` job which is doing the same but with `regctl`?
Because the helm version bump needs a dependency, to work properly in both master commits and production tags. This dependency could only be the `publish:image-multiplatform` job