### PR TITLE
chore: made vendor check get skipped if no vendor folder available

### DIFF
--- a/.gitlab-ci-check-golang-lint.yml
+++ b/.gitlab-ci-check-golang-lint.yml
@@ -48,12 +48,13 @@ test:govendor-check:
     - mender-qa-worker-generic-light
   stage: test
   needs: []
+  rules:
+    - exists:
+      - vendor
   variables:
     GOLANG_VERSION: "1.20"
   image: golang:${GOLANG_VERSION}
   script:
-    - if [ -d vendor ]; then
-    -   go mod tidy
-    -   go mod vendor
-    -   git diff --exit-code
-    - fi
+    - go mod tidy
+    - go mod vendor
+    - git diff --exit-code

--- a/.gitlab-ci-check-golang-static.yml
+++ b/.gitlab-ci-check-golang-static.yml
@@ -55,12 +55,13 @@ test:govendor-check:
     - mender-qa-worker-generic-light
   stage: test
   needs: []
+  rules:
+    - exists:
+      - vendor
   variables:
     GOLANG_VERSION: "1.20"
   image: golang:${GOLANG_VERSION}
   script:
-    - if [ -d vendor ]; then
-    -   go mod tidy
-    -   go mod vendor
-    -   git diff --exit-code
-    - fi
+    - go mod tidy
+    - go mod vendor
+    - git diff --exit-code


### PR DESCRIPTION
recently I've come across the vendor check job taking a while to start ([here](https://gitlab.com/Northern.tech/Mender/deployments-enterprise/-/jobs/5212756466)), so this should skip it if no `vendor` folder is present