### PR TITLE
fix: prevented non-yocto go license check from running

### DIFF
--- a/.gitlab-ci-check-license.yml
+++ b/.gitlab-ci-check-license.yml
@@ -74,6 +74,10 @@ test:check-license:golang:
     - exists:
         - licenses.csv
         - go.mod
+      when: always
+    - exists:
+        - LIC_FILES_CHKSUM.sha256
+      when: never
   needs: []
   before_script:
     - go install github.com/google/go-licenses@latest


### PR DESCRIPTION
- the exists requirement turned out not to be AND but OR checking for existence

this should address [this job failure](https://gitlab.com/Northern.tech/Mender/mender/-/jobs/5216358650)