### PR TITLE
fix: prevented non-yocto go license check from running pt2

### DIFF
--- a/.gitlab-ci-check-license.yml
+++ b/.gitlab-ci-check-license.yml
@@ -73,7 +73,6 @@ test:check-license:golang:
   rules:
     - exists:
         - licenses.csv
-        - go.mod
       when: always
     - exists:
         - LIC_FILES_CHKSUM.sha256


### PR DESCRIPTION
- the existence of go.mod still was enough to trigger the job, so since the repos running this newer check are golang so far, default to golang and let other environments base their trigger on more unique files

Ticket: None
Changelog: None