### PR TITLE
fix: Accept `chore` context for changelogs

### DIFF
--- a/commitlint/commitlint
+++ b/commitlint/commitlint
@@ -23,7 +23,7 @@ BEGIN {
     EMPTY_LINE = "^$"
 
     ## Footer
-    CHANGELOG_PREFIX="^Changelog(\\((fix|feat)+\\))?: "
+    CHANGELOG_PREFIX="^Changelog(\\((fix|feat|chore)+\\))?: "
     CHANGELOG=CHANGELOG_PREFIX ".*"
     TICKET="Ticket: .*"
     BREAKING_CHANGE="BREAKING[- ]CHANGE: .*"


### PR DESCRIPTION
Useful for example to downgrade the changelog of a `feat` or `fix` commit.