### PR TITLE
fix(commitlint): Fix the definitions of WORD and COMMIT_SCOPE

### DIFF
--- a/commitlint/commitlint
+++ b/commitlint/commitlint
@@ -18,8 +18,8 @@ BEGIN {
     ## Header
     COMMIT_TYPE = "^(fix|feat|build|chore|ci|docs|perf|refac|revert|style|test)"
     LINE=".*"
-    WORD = "[[:print:]]+"
-    COMMIT_SCOPE = "^\\("WORD"\\)"
+    WORD = "[-_[:alnum:]]+"
+    COMMIT_SCOPE = "^\\(("WORD")\\)"
     EMPTY_LINE = "^$"
 
     ## Footer

--- a/commitlint/commitlint
+++ b/commitlint/commitlint
@@ -297,6 +297,7 @@ function parse_footer() {
                 match(tok, CHERRY_PICK) ||
                 match(tok, CANCEL_CHANGELOG) ||
                 match(tok, SIGN_OFF_LINE))) {
+            debugf("Got token: %s\n", tok)
             error("Only Changelogs, Tickets, Sign-offs, cherry pick notes and BREAKING CHANGES allowed in the FOOTER")
         }
         if (match(tok, CHANGELOG)) {

--- a/commitlint/commitlint
+++ b/commitlint/commitlint
@@ -161,6 +161,22 @@ function _advance() {
         _tok_type = "SIGN_OFF_LINE"
         return _tok
     }
+    if (match(line, CHERRY_PICK)) {
+        _tok = line
+        debugf("Matched CHERRY_PICK: %s", _tok)
+        VAL = _tok;
+        line = ""
+        _tok_type = "CHERRY_PICK"
+        return _tok
+    }
+    if (match(line, CANCEL_CHANGELOG)) {
+        _tok = line
+        debugf("Matched CANCEL_CHANGELOG: %s", _tok)
+        VAL = _tok;
+        line = ""
+        _tok_type = "CANCEL_CHANGELOG"
+        return _tok
+    }
     if (match(line, WORD)) {
         _tok = substr(line, 1, RLENGTH)
          debugf("Matched LINE: %s", _tok)

--- a/commitlint/testcommitlint.sh
+++ b/commitlint/testcommitlint.sh
@@ -257,6 +257,16 @@ Changelog: None
 BREAKING-CHANGE: No more bueno
 "
 
+assert "true" \
+       "fix with scope and function in description" \
+       "fix(client): Some change in Func() made
+
+Changelog: None
+Ticket: None
+
+Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
+"
+
 
 assert "true" \
        "fix with cherry-pick footer" \


### PR DESCRIPTION
A word is not a sequence of arbitrary **printable** characters. It's shouldn't contain dashes either, but in our case it simplifies things. For example, commit scope can then be a word in parantheses.

This fixes issues with commit messages containing scope and parantheses in the title, e.g. when mentioning SomeFunction().