### PR TITLE
ci: Revert "ci: Add descriptions to the variables and simplify docume…

### DIFF
--- a/.gitlab-ci-check-docker-acceptance.yml
+++ b/.gitlab-ci-check-docker-acceptance.yml
@@ -5,23 +5,28 @@
 #
 # It assumes the following files:
 # * Dockerfile.acceptance-testing: to build the the binary with test coverage.
-# * tests/Dockerfile (optional) to build a custom Python test runner.
+# * tests/Dockerfile to build the Python test runner.
 # * tests/docker-compose-acceptance.yml for the tests composition runtime.
 # * tests/docker-compose-acceptance-enterprise.yml (optional) for Enterprise tests.
 #
-
-variables:
-  DOCKER_REPOSITORY:
-    description: "Full qualified name of the container image"
-  INTEGRATION_REV:
-    description: "Version of integration repository"
-    value: master
-  COVERALLS_TOKEN:
-    description: "Token from coveralls.io for this repository"
-  REGISTRY_MENDER_IO_USERNAME:
-    description: "Username for registry.mender.io, if images are to be pulled"
-  REGISTRY_MENDER_IO_PASSWORD:
-    description: "Password for registry.mender.io, if images are to be pulled"
+# Requires DOCKER_REPOSITORY variable to be set in the calling Pipeline.
+# Add it to the project in hand through Gitlab's include functionality
+#
+# variables:
+#   DOCKER_REPOSITORY: <Image FQN, i.e mendersoftware/reponame>
+#   INTEGRATION_REV: <integration revision> (optional, defaults to master)
+# include:
+#   - project: 'Northern.tech/Mender/mendertesting'
+#     file: '.gitlab-ci-check-docker-acceptance.yml'
+#
+# Requires the following variables set in the project CI/CD settings:
+#   COVERALLS_TOKEN: Token from coveralls.io for this repository
+#
+# If the tests require access to Mender Registry hosted images, it
+# will require also the following vabiables:
+#   REGISTRY_MENDER_IO_USERNAME: Username for registry.mender.io
+#   REGISTRY_MENDER_IO_PASSWORD: Password for registry.mender.io
+#
 
 stages:
   - test_prep
@@ -77,7 +82,7 @@ test:acceptance_tests:
     - docker:20.10.21-dind
   before_script:
     - apk add git bash
-    - git clone -b ${INTEGRATION_REV} --depth=1 https://github.com/mendersoftware/integration.git mender-integration
+    - git clone -b ${INTEGRATION_REV:-master} --depth=1 https://github.com/mendersoftware/integration.git mender-integration
     - mv mender-integration/extra/travis-testing/* tests/
     - mv docs/* tests/
     - mv ${CI_PROJECT_NAME} tests/


### PR DESCRIPTION
…ntation"

Setting no `value` on required variables in effect makes them blank when running pipelines from GUI, and pipeline variables take precedence over project and group variables.

This reverts commit 4a4200a5cfcbdaa25b63115569e820d850a46905.