### PR TITLE
Helm rollout: using project runner

### DIFF
--- a/.gitlab-ci-check-helm-version-bump.yml
+++ b/.gitlab-ci-check-helm-version-bump.yml
@@ -32,6 +32,8 @@ helm-version-bump:
   rules:
     - if: $CI_PIPELINE_SOURCE == "pipeline"
   stage: version-bump
+  tags:
+    - mender-qa-worker-generic-light
   image: registry.gitlab.com/northern.tech/mender/mender-test-containers:aws-k8s-v1-master
   before_script:
     - |


### PR DESCRIPTION
instead of shared runners

Ticket: None
Changelog: None