### PR TITLE
Publish the last stable build to the CI registry

### DIFF
--- a/.gitlab-ci-check-docker-build.yml
+++ b/.gitlab-ci-check-docker-build.yml
@@ -150,6 +150,7 @@ build:docker-multiplatform:
       --cache-to type=registry,ref=${CI_REGISTRY_IMAGE}:ci_cache,mode=max
       --cache-from type=registry,ref=${CI_REGISTRY_IMAGE}:ci_cache
       --tag ${GITLAB_REGISTRY_TAG}
+      --tag ${CI_REGISTRY_IMAGE}:${CI_COMMIT_REF_NAME}
       --file ${DOCKER_DIR:-.}/${DOCKERFILE:-Dockerfile}
       --build-arg GIT_COMMIT_TAG="${DOCKER_PUBLISH_COMMIT_TAG}"
       --platform $MULTIPLATFORM_PLATFORMS


### PR DESCRIPTION
To be used later in the QA pipeline

Ticket: QA-647
Changelog: None