### PR TITLE
ci: Run acceptance tests with a candidate base image

### DIFF
--- a/.gitlab-ci-check-docker-acceptance.yml
+++ b/.gitlab-ci-check-docker-acceptance.yml
@@ -98,6 +98,11 @@ test:acceptance_tests:
     - if [ -n "$REGISTRY_MENDER_IO_USERNAME" ]; then
     -   docker login -u "$REGISTRY_MENDER_IO_USERNAME" -p "$REGISTRY_MENDER_IO_PASSWORD" registry.mender.io
     - fi
+    - if [ -n "$MENDER_TEST_CONTAINERS_CANDIDATE_TAG" ]; then
+    -   sed -i.bak -e "s,mendersoftware/mender-test-containers:acceptance-testing,$MENDER_TEST_CONTAINERS_CANDIDATE_TAG," tests/docker-compose-acceptance.yml
+    -   diff -u tests/docker-compose-acceptance.yml.bak tests/docker-compose-acceptance.yml || true
+    -   echo $CI_REGISTRY_PASSWORD | docker login -u $CI_REGISTRY_USER $CI_REGISTRY --password-stdin
+    - fi
   script:
     - TESTS_DIR=$(pwd)/tests $(pwd)/tests/run-test-environment acceptance $(pwd)/mender-integration $(pwd)/tests/docker-compose-acceptance.yml
     - if [ -f $(pwd)/tests/docker-compose-acceptance-enterprise.yml ]; then


### PR DESCRIPTION
Three friends:
* https://github.com/mendersoftware/mender-qa/pull/723
* https://github.com/mendersoftware/mendertesting/pull/315
* https://github.com/mendersoftware/mender-test-containers/pull/495

Ticket: QA-505

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>
(cherry picked from commit 2b101b91da74c5434783e103df6e123a0a0deca8)