### PR TITLE
revert: "test: Don't check vendor folders for correct Python formatting."

### DIFF
--- a/check_python_code_format
+++ b/check_python_code_format
@@ -40,7 +40,7 @@ function cleanup() {
     rm -f ${tfile}
 }
 
-if  ! black --check --exclude 'vendor/.*' --verbose . >& ${tfile}; then
+if  ! black --check --verbose . >& ${tfile}; then
     cat ${tfile} | grep -v "good job" | grep -v "wasn't modified on disk since last run" >&2 || true
     echo >&2 ""
     echo >&2 "Please fix your code locally with: black ."


### PR DESCRIPTION
Turns out that this conflicts with loading custom excludes from `pyproject.toml`. Looks like there is no easy way to have both, so revert the generic fix and rely on filters in each repo instead.

This reverts commit 01aa2e3dc1c3d1b909ef319739acffe38e4aea11.