### PR TITLE
Move env var to direct group download

### DIFF
--- a/.gitlab-ci-check-commits-signoffs.yml
+++ b/.gitlab-ci-check-commits-signoffs.yml
@@ -9,7 +9,7 @@ test:check-commits:
   needs: []
   except:
     - /^(master|hosted|staging|production|saas-v[0-9.]+|[0-9]+\.[0-9]+\.x)$/
-  image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/alpine
+  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/alpine
   variables:
     GIT_STRATEGY: clone # clone entire repo instead of reusing workspace
     GIT_DEPTH: 0 # avoid shallow clone, this test requires full git history

--- a/.gitlab-ci-check-commits.yml
+++ b/.gitlab-ci-check-commits.yml
@@ -9,7 +9,7 @@ test:check-commits:
   needs: []
   except:
     - /^(master|hosted|staging|production|saas-v[0-9.]+|[0-9]+\.[0-9]+\.x|[0-9]+\.[0-9]+\.[0-9]+)$/
-  image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/alpine
+  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/alpine
   variables:
     GIT_STRATEGY: clone # clone entire repo instead of reusing workspace
     GIT_DEPTH: 0 # avoid shallow clone, this test requires full git history

--- a/.gitlab-ci-check-license.yml
+++ b/.gitlab-ci-check-license.yml
@@ -39,7 +39,7 @@ test:check-license:
       - licenses.csv
       when: never
     - when: always
-  image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/alpine
+  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/alpine
   variables:
     GIT_STRATEGY: clone # clone entire repo instead of reusing workspace
     GIT_DEPTH: 0 # avoid shallow clone, this test requires full git history
@@ -66,7 +66,7 @@ test:check-license:
     - $SCRIPT_PATH/check_license.sh
 
 test:check-license:golang:
-  image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/golang:1.21-alpine
+  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/golang:1.21-alpine
   tags:
     - hetzner-amd-beefy
   stage: test
@@ -91,7 +91,7 @@ test:check-license-source:
     - hetzner-amd-beefy
   stage: test
   needs: []
-  image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/alpine
+  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/alpine
   variables:
     GIT_STRATEGY: clone # clone entire repo instead of reusing workspace
     GIT_DEPTH: 0 # avoid shallow clone, this test requires full git history

--- a/.gitlab-ci-check-python3-format.yml
+++ b/.gitlab-ci-check-python3-format.yml
@@ -50,7 +50,7 @@ stages:
 test:check-python3-formatting:
   tags:
     - hetzner-amd-beefy
-  image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/python:3.8-alpine
+  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/python:3.8-alpine
   stage: test
   needs: []
   variables:

--- a/.gitlab-ci-check-shell-format.yml
+++ b/.gitlab-ci-check-shell-format.yml
@@ -30,7 +30,7 @@ test:check-shell-formatting:
     - hetzner-amd-beefy
   stage: test
   needs: []
-  image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/alpine:3.13
+  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/alpine:3.13
   before_script:
     - SHELL_SCRIPTS=$(find . -type f -name "*.sh")
   script:

--- a/.gitlab-ci-github-status-updates.yml
+++ b/.gitlab-ci-github-status-updates.yml
@@ -15,7 +15,7 @@ stages:
   tags:
     - hetzner-amd-beefy
   # Keep overhead low by using a small image with curl preinstalled.
-  image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/appropriate/curl
+  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/appropriate/curl
   before_script:
     - |
       send_status() {

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -66,7 +66,7 @@ test:unit:
 test:unit:commitlint:
   tags:
     - hetzner-amd-beefy
-  image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/alpine
+  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/alpine
   stage: test
   before_script:
     - apk add --no-cache bash gawk


### PR DESCRIPTION
Using CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX instead of CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX to better manage permissions

Ticket: QA-705
Changelog: None