### PR TITLE
ci: Replace base image for `curl` only jobs

### DIFF
--- a/.gitlab-ci-check-docker-acceptance.yml
+++ b/.gitlab-ci-check-docker-acceptance.yml
@@ -167,7 +167,7 @@ coveralls:finish-build:
   variables:
     COVERALLS_WEBHOOK_URL: "https://coveralls.io/webhook"
     COVERALLS_RERUN_BUILD_URL: "https://coveralls.io/rerun_build"
-  image: appropriate/curl
+  image: curlimages/curl-base
   script:
     - 'curl -k ${COVERALLS_WEBHOOK_URL}?repo_token=${COVERALLS_TOKEN} -d "payload[build_num]=$CI_PIPELINE_ID&payload[status]=done"'
     - 'curl -k "${COVERALLS_RERUN_BUILD_URL}?repo_token=${COVERALLS_TOKEN}&build_num=${CI_PIPELINE_ID}"'

--- a/.gitlab-ci-check-golang-unittests-v2.yml
+++ b/.gitlab-ci-check-golang-unittests-v2.yml
@@ -88,7 +88,7 @@ coveralls:finish-build:
   variables:
     COVERALLS_WEBHOOK_URL: "https://coveralls.io/webhook"
     COVERALLS_RERUN_BUILD_URL: "https://coveralls.io/rerun_build"
-  image: appropriate/curl
+  image: curlimages/curl-base
   script:
     - 'curl -k ${COVERALLS_WEBHOOK_URL}?repo_token=${COVERALLS_TOKEN} -d "payload[build_num]=$CI_PIPELINE_ID&payload[status]=done"'
     - 'curl -k "${COVERALLS_RERUN_BUILD_URL}?repo_token=${COVERALLS_TOKEN}&build_num=${CI_PIPELINE_ID}"'

--- a/.gitlab-ci-check-golang-unittests.yml
+++ b/.gitlab-ci-check-golang-unittests.yml
@@ -138,7 +138,7 @@ coveralls:finish-build:
   variables:
     COVERALLS_WEBHOOK_URL: "https://coveralls.io/webhook"
     COVERALLS_RERUN_BUILD_URL: "https://coveralls.io/rerun_build"
-  image: appropriate/curl
+  image: curlimages/curl-base
   script:
     - 'curl -k ${COVERALLS_WEBHOOK_URL}?repo_token=${COVERALLS_TOKEN} -d "payload[build_num]=$CI_PIPELINE_ID&payload[status]=done"'
     - 'curl -k "${COVERALLS_RERUN_BUILD_URL}?repo_token=${COVERALLS_TOKEN}&build_num=${CI_PIPELINE_ID}"'

--- a/.gitlab-ci-github-status-updates.yml
+++ b/.gitlab-ci-github-status-updates.yml
@@ -15,7 +15,7 @@ stages:
   tags:
     - hetzner-amd-beefy
   # Keep overhead low by using a small image with curl preinstalled.
-  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/appropriate/curl
+  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/curlimages/curl-base
   before_script:
     - |
       send_status() {

--- a/mender-ci-common.sh
+++ b/mender-ci-common.sh
@@ -61,7 +61,7 @@ mender_ci_save_tmp_artifact() {
 # checksum (see mender_ci_save_tmp_artifact).
 mender_ci_load_tmp_artifact() {
     if [ -z "$1" ]; then
-        echo "Usage $0 file-to-save [project-name] [pipeline-id]"
+        echo "Usage $0 file-to-load [project-name] [pipeline-id]"
         exit 1
     fi
     user_file="$1"


### PR DESCRIPTION
The container image `appropriate/curl` has not been updated for 6 years.

See:
* https://github.com/mendersoftware/mender-qa/commit/1b080adb31432251eb0e9abc6374f8696a02edd3