### PR TITLE
ci: avoiding docker hub limits

### DIFF
--- a/.gitlab-ci-check-docker-build.yml
+++ b/.gitlab-ci-check-docker-build.yml
@@ -142,6 +142,7 @@ build:docker-multiplatform:
     - docker:20.10.21-dind
   before_script:
     - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
+    - *docker_login_registries
   script:
     - echo "building ${CI_PROJECT_NAME} for ${DOCKER_BUILD_SERVICE_IMAGE}"
     - docker context create builder


### PR DESCRIPTION
Logging into the docker hub in the build steps to avoid the docker hub limits

Ticket: None
Changelog: None