### PR TITLE
chore: removed deprecated linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,7 +16,6 @@ run:
 linters:
   enable:
     - bodyclose
-    - deadcode
     - errcheck
     - gocyclo
     - gofmt
@@ -26,10 +25,8 @@ linters:
     - ineffassign
     - lll
     - staticcheck
-    - structcheck
     - typecheck
     - unused
-    - varcheck
 
 linters-settings:
   gocyclo:


### PR DESCRIPTION
my local linter executions were failing due to the following:
```
[error] level=warning msg="The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter. Replaced by unused."
level=warning msg="The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter. Replaced by unused."
level=warning msg="The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter. Replaced by unused."
level=error msg="[linters_context] deadcode: This linter is fully inactivated: it will not produce any reports."
level=error msg="[linters_context] structcheck: This linter is fully inactivated: it will not produce any reports."
level=error msg="[linters_context] varcheck: This linter is fully inactivated: it will not produce any reports."
```
so I removed them from the config