### PR TITLE
Avoid docker login hangs when missing creds  

### DIFF
--- a/.gitlab-ci-check-docker-build.yml
+++ b/.gitlab-ci-check-docker-build.yml
@@ -78,10 +78,18 @@ stages:
   - publish
 
 .docker_login_registries: &docker_login_registries |
-  docker login -u "$REGISTRY_MENDER_IO_USERNAME" -p "$REGISTRY_MENDER_IO_PASSWORD" registry.mender.io || \
-    echo "Warning: registry.mender.io credentials unavailable or invalid"
-  docker login -u "$DOCKER_HUB_USERNAME" -p "$DOCKER_HUB_PASSWORD" || \
-    echo "Warning: Docker credentials unavailable or invalid"
+  if [ -n "$REGISTRY_MENDER_IO_PASSWORD" ]; then \
+    echo "${REGISTRY_MENDER_IO_PASSWORD}" | docker login -u "${REGISTRY_MENDER_IO_USERNAME}" --password-stdin registry.mender.io || \
+    echo "Warning: registry.mender.io credentials invalid"; \
+  else \
+    echo "Warning: registry.mender.io credentials unavailable"; \
+  fi; \
+  if [ -n "$DOCKER_HUB_PASSWORD" ]; then \
+    echo "${DOCKER_HUB_PASSWORD}" | docker login -u "${DOCKER_HUB_USERNAME}" --password-stdin || \
+    echo "Warning: Docker Hub credentials invalid"; \
+  else \
+    echo "Warning: Docker Hub credentials unavailable"; \
+  fi
 
 .export_docker_vars: &export_docker_vars |
   DOCKER_BUILD_TAG=${CI_COMMIT_REF_SLUG:-local}


### PR DESCRIPTION
Ticket: QA-752

Recently, a docker login failure is waiting for 15 min to wait for web browser login. This slows down a lot the pipelines that don't need login to docker, but they are reusing the mendertesting shared pipeline configurations.
With this change, we'll ignore the docker login if the variable is not set.