### PR TITLE
chore(ci): centralize git cliff configuration

### DIFF
--- a/utils/cliff.toml
+++ b/utils/cliff.toml
@@ -1,0 +1,122 @@
+# git-cliff ~ configuration file
+# https://git-cliff.org/docs/configuration
+
+
+# Documentation:
+# Set a script step like this in the pipeline where git cliff is used:
+# wget --output-document cliff.toml https://raw.githubusercontent.com/mendersoftware/mendertesting/master/utils/cliff.toml
+
+
+[changelog]
+# template for the changelog footer
+header = """---"""
+# template for the changelog body
+# https://keats.github.io/tera/docs/#introduction
+body = """
+{% if version %}\
+    ## {{ version }} - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+    ## [unreleased]
+{% endif %}\
+
+{% macro render_commits(commits) %}
+    {% for commit in commits
+    | filter(attribute="scope")
+    | unique(attribute="message") 
+    | sort(attribute="scope") %}
+        - *({{commit.scope}})* {{ commit.message | upper_first }}
+        {%- if commit.breaking %}
+        {% raw %}  {% endraw %}- **BREAKING**: {{commit.breaking_description}}
+        {%- endif -%}
+    {%- endfor -%}
+    {% raw %}\n{% endraw %}\
+    {%- for commit in commits | unique(attribute="message") %}
+        {%- if commit.scope -%}
+        {% else -%}
+            - {{ commit.message | upper_first }}\
+                  {% if commit.links %}\
+                    ({% for link in commit.links | unique(attribute="text") %}\
+                        [{{ link.text }}]({{ link.href }})\
+                    {% endfor -%})\
+                  {% endif %} \
+                  ([{{ commit.id | truncate(length=7, end="") }}]\
+                  (https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}/commit/{{ commit.id }})) \
+                  {% if commit.github.username %} by @{{ commit.github.username }}{%- endif %}\
+                  {% if commit.github.pr_number %} in #{{ commit.github.pr_number }}{%- endif %}
+            {% if commit.breaking -%}
+            {% raw %}  {% endraw %}- **BREAKING**: {{commit.breaking_description}}
+            {% endif -%}
+        {% endif -%}
+            {% if commit.body -%}
+              {% for line in commit.body | split(pat="\n") -%}
+                {% raw %}  {% endraw %}{{ line }}
+              {% endfor -%}
+            {% endif -%}
+    {% endfor -%}
+{% endmacro input %}\
+
+{% for group, commits in commits | group_by(attribute="group")  %}
+    {% if group is starting_with("Dependabot") %}
+        {% set_global dependencies = commits %}
+        {% continue %}
+    {% endif %}
+    ### {{ group | upper_first }}
+    {{ self::render_commits(commits=commits) }}
+    {% raw %}\n{% endraw %}\
+{% endfor %}\n
+{% if dependencies is defined %}
+    ### Dependabot bumps
+    {{ self::render_commits(commits=dependencies) }}
+{% endif %}
+"""
+# template for the changelog footer
+footer = """---"""
+# remove the leading and trailing whitespace from the templates
+trim = true
+
+
+[git]
+# parse the commits based on https://www.conventionalcommits.org
+conventional_commits = true
+# filter out the commits that are not conventional
+filter_unconventional = true
+# process each line of a commit as an individual commit
+split_commits = false
+# regex for parsing and grouping commits
+commit_parsers = [
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Bug Fixes" },
+    { message = "^doc", group = "Documentation" },
+    { message = "^perf", group = "Performance" },
+    { message = "^refactor", group = "Refactor" },
+    { message = "^style", group = "Styling" },
+    { message = "^test", group = "Testing", skip = true },
+    { message = ".*Changelog: None", skip = true },
+    { message = "^chore: bump", group = "Security" },
+    { message = "^chore|^ci", skip = true },
+    { body = ".*security", group = "Security" },
+]
+link_parsers = [
+    { pattern = "MEN-(\\d+)", href = "https://northerntech.atlassian.net/browse/MEN-$1" },
+    { pattern = "SEC-(\\d+)", href = "https://northerntech.atlassian.net/browse/SEC-$1" },
+    { pattern = "QA-(\\d+)", href = "https://northerntech.atlassian.net/browse/QA-$1" },
+]
+
+# protect breaking changes from being skipped due to matching a skipping commit_parser
+protect_breaking_commits = false
+# filter out the commits that are not matched by commit parsers
+filter_commits = false
+# regex for matching git tags
+tag_pattern = "[0-9].*"
+# regex for skipping tags
+skip_tags = "0.1.0-beta.1"
+# regex for ignoring tags
+ignore_tags = ""
+# sort the tags topologically
+topo_order = false
+# sort the commits inside sections by oldest/newest order
+sort_commits = "oldest"
+
+[bump]
+features_always_bump_minor = true
+breaking_always_bump_major = true


### PR DESCRIPTION
By exposing the cliff.toml file in the mendertesting repository, other projects and gitlab cicd jobs could fetch it to create changelogs with a predefined standard formatting.

Ticket: QA-763