### PR TITLE
ci: fix no changelog found

### DIFF
--- a/utils/cliff.toml
+++ b/utils/cliff.toml
@@ -72,7 +72,7 @@ body = """
     ### Dependabot bumps
     {{ self::render_commits(commits=dependencies) }}
 {% endif %}
-{% if not commit %}
+{% if not commits %}
     No Changelog found.
 {% endif %}
 """

--- a/utils/cliff.toml.scoped
+++ b/utils/cliff.toml.scoped
@@ -78,7 +78,7 @@ body = """
     ### Dependabot bumps
     {{ self::render_commits(commits=dependencies) }}
 {% endif %}
-{% if not commit %}
+{% if not commits %}
     No Changelog found.
 {% endif %}"""
 


### PR DESCRIPTION
The No changelog found message is displayed even with new commits, caused by a typo

Changelog: None
Ticket: None