### PR TITLE
ci: Add quiet flag to upload/download S3 artifacts

### DIFF
--- a/mender-ci-common.sh
+++ b/mender-ci-common.sh
@@ -52,7 +52,7 @@ mender_ci_save_tmp_artifact() {
     sha256sum ${user_file} > ${CI_PROJECT_DIR}/checksums/$(basename ${user_file}).sha256
     env AWS_ACCESS_KEY_ID=$TMP_STORAGE_AWS_ACCESS_KEY_ID \
             AWS_SECRET_ACCESS_KEY=$TMP_STORAGE_AWS_SECRET_ACCESS_KEY \
-            aws s3 cp ${user_file} s3://mender-gitlab-tmp-storage/$project_name/$pipeline_id/$(basename ${user_file})
+            aws s3 cp --quiet ${user_file} s3://mender-gitlab-tmp-storage/$project_name/$pipeline_id/$(basename ${user_file})
 }
 
 # Usage: mender_ci_load_tmp_artifact file-to-load
@@ -73,6 +73,6 @@ mender_ci_load_tmp_artifact() {
     fi
     env AWS_ACCESS_KEY_ID=$TMP_STORAGE_AWS_ACCESS_KEY_ID \
             AWS_SECRET_ACCESS_KEY=$TMP_STORAGE_AWS_SECRET_ACCESS_KEY \
-            aws s3 cp s3://mender-gitlab-tmp-storage/$project_name/$pipeline_id/$(basename ${user_file}) ${user_file}
+            aws s3 cp --quiet s3://mender-gitlab-tmp-storage/$project_name/$pipeline_id/$(basename ${user_file}) ${user_file}
     sha256sum -c ${CI_PROJECT_DIR}/checksums/$(basename ${user_file}).sha256
 }


### PR DESCRIPTION
This is noisy and can flood the CI logs.