### PR TITLE
chore: don't redirect shasum command to null in check_license.sh 

### DIFF
--- a/check_license.sh
+++ b/check_license.sh
@@ -75,17 +75,8 @@ cleanup() {
 }
 sed '/^$/d' $CHKSUM_FILE > $TMP_CHKSUM_FILE
 
-# Collect only stderr from the subcommand
-output="$(
-          exec 3>&1
-          shasum --warn --algorithm 256 --check $TMP_CHKSUM_FILE > /dev/null 2>&3
-)"
-
-if echo "$output" | grep -q 'line is improperly formatted' -; then
-    echo >&2 "Some line(s) in the LIC_FILE_CHKSUM.sha256 file are misformed"
-    cat $TMP_CHKSUM_FILE
-    exit 1
-fi
+# Check shasum
+shasum --warn --algorithm 256 --check $TMP_CHKSUM_FILE --quiet --strict || exit 1
 
 # Unlisted licenses not allowed.
 while read -r file; do

--- a/license_test.go
+++ b/license_test.go
@@ -342,5 +342,5 @@ func TestMisformedLicenseChecksumLines(t *testing.T) {
 
 	err = checkMenderCompliance()
 	assert.Error(t, err, err.Error())
-	assert.Contains(t, err.Error(), "Some line(s) in the LIC_FILE_CHKSUM.sha256 file are misformed")
+	assert.Contains(t, err.Error(), "shasum: WARNING: 1 line is improperly formatted")
 }


### PR DESCRIPTION
This lets us see which files have the wrongly computed checksum, it prints:
* `shasum: WARNING: 1 computed checksum did NOT match` 
   `path/to/license/LICENSE: FAILED`

instead of just :
* `shasum: WARNING: 1 computed checksum did NOT match`