### PR TITLE
ci: Remove skip-tags from cliff.toml

### DIFF
--- a/utils/cliff.toml
+++ b/utils/cliff.toml
@@ -116,8 +116,6 @@ protect_breaking_commits = false
 filter_commits = false
 # regex for matching git tags
 tag_pattern = "v*[0-9].*"
-# regex for skipping tags
-skip_tags = "beta|alpha|rc"
 # regex for ignoring tags
 ignore_tags = ""
 # sort the tags topologically

--- a/utils/cliff.toml.scoped
+++ b/utils/cliff.toml.scoped
@@ -122,8 +122,6 @@ protect_breaking_commits = false
 filter_commits = false
 # regex for matching git tags
 tag_pattern = "v*[0-9].*"
-# regex for skipping tags
-skip_tags = "beta|alpha|rc"
 # regex for ignoring tags
 ignore_tags = ""
 # sort the tags topologically


### PR DESCRIPTION
Tags are managed by release-please so it will have to follow whatever is used there.