### PR TITLE
chore: bump golang version

### DIFF
--- a/.gitlab-ci-check-golang-unittests-v2.yml
+++ b/.gitlab-ci-check-golang-unittests-v2.yml
@@ -28,7 +28,7 @@ test:unit:
   needs: []
   except:
     - /^saas-[a-zA-Z0-9.]+$/
-  image: golang:1.20
+  image: golang:1.23.4
   services:
     - "mongo:${MONGO_VERSION}"
   before_script:
@@ -58,7 +58,7 @@ publish:unittests:
   stage: publish
   except:
     - /^saas-[a-zA-Z0-9.]+$/
-  image: golang:1.20
+  image: golang:1.23.4
   dependencies:
     - test:unit
   before_script:

--- a/.gitlab-ci-check-golang-unittests.yml
+++ b/.gitlab-ci-check-golang-unittests.yml
@@ -41,7 +41,7 @@ test:unit:
   needs: []
   except:
     - /^saas-[a-zA-Z0-9.]+$/
-  image: golang:1.20.4
+  image: golang:1.23.4
   services:
     - mongo:6.0
   variables:
@@ -100,7 +100,7 @@ publish:unittests:
   stage: publish
   except:
     - /^saas-[a-zA-Z0-9.]+$/
-  image: golang:1.20-alpine3.17
+  image: golang:1.23.4-alpine3.21
   dependencies:
     - test:unit
   before_script:


### PR DESCRIPTION
We need a newer golang version in the unit tests, because go now allows patch-versions for the go version in the go.mod - which some newer dependencies require.