### PR TITLE
chore: bump mongodb in golang unit tests

### DIFF
--- a/.gitlab-ci-check-golang-unittests.yml
+++ b/.gitlab-ci-check-golang-unittests.yml
@@ -47,8 +47,8 @@ test:unit:
   variables:
     GIT_STRATEGY: clone # clone entire repo instead of reusing workspace
     GIT_DEPTH: 0 # avoid shallow clone, this test requires full git history
-    MONGODB_DEBIAN_RELEASE: "buster"
-    MONGODB_VERSION: "4.4"
+    MONGODB_DEBIAN_RELEASE: "bookworm"
+    MONGODB_VERSION: "8.0"
     TEST_MONGO_URL: "mongodb://mongo"
   before_script:
     # Install JUnit test reporting formatter


### PR DESCRIPTION
We can't get libssl1.1 from the upstream Debian after updating the image.