### PR TITLE
ci: Update golang image for running license check

### DIFF
--- a/.gitlab-ci-check-license.yml
+++ b/.gitlab-ci-check-license.yml
@@ -66,7 +66,7 @@ test:check-license:
     - $SCRIPT_PATH/check_license.sh
 
 test:check-license:golang:
-  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/golang:1.21-alpine
+  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/golang:${GOLANG_VERSION:-1.24}
   tags:
     - hetzner-amd-beefy
   stage: test


### PR DESCRIPTION
Added env variable override to allow reusing consistent versioning.