### PR TITLE
ci: Remove apk(1) call in check-license call

### DIFF
--- a/.gitlab-ci-check-license.yml
+++ b/.gitlab-ci-check-license.yml
@@ -86,7 +86,6 @@ test:check-license:golang:
   needs: []
   before_script:
     - go install github.com/google/go-licenses@latest
-    - apk add --no-cache git
     - git clone --no-tags --depth=1 --single-branch https://github.com/mendersoftware/mendertesting /tmp/mendertesting
   script:
     - go-licenses report . --ignore github.com/mendersoftware --template /tmp/mendertesting/go_licenses_format.tpl > licenses.csv


### PR DESCRIPTION
The debian golang image already has git(1) installed.