### PR TITLE
fix: Do not override EXTRA_DOCKER_ARGS from parent scope

### DIFF
--- a/.gitlab-ci-check-docker-build.yml
+++ b/.gitlab-ci-check-docker-build.yml
@@ -71,9 +71,6 @@ variables:
   MULTIPLATFORM_PLATFORMS:
     description: "Comma-separated list of targets to build os/arch[/<version>]"
     value: "linux/amd64,linux/arm64"
-  EXTRA_DOCKER_ARGS:
-    description: "User specified extra arguments for docker build command"
-    value: ""
 
 stages:
   - build


### PR DESCRIPTION
Depending on the trigger of the build, the variable value from the template will get precedence, clearing the intended value of the user.

This is the case for example when running a manual pipeline through GUI, where this variable is blanked out. See a failure pipeline here:
* https://gitlab.com/Northern.tech/Mender/mender-convert/-/jobs/9696025686