### PR TITLE
QA-1032: Add CI/CD component commit-lint

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,21 @@
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+
+  rules: {
+    'body-max-line-length': [1, 'always', 100],
+    'subject-case': [1, 'always', ['lower-case', 'sentence-case']],
+    'signed-off-by': [2, 'always', 'Signed-off-by'],
+    'body-leading-blank': [2, 'always'], // body must be preceded by a blank line
+                                         // exit with error if not
+  },
+
+  helpUrl: `
+  Commit messages must follow conventional commit format:
+  https://www.conventionalcommits.org/en/v1.0.0/#summary
+      type(optional-scope): subject
+
+      [optional body]
+  * To bypass pre-commit hooks run 'git commit --no-verify'
+  >>> Use "npm run commit" for interactive prompt. <<<
+  `
+};

--- a/templates/commit-lint.yml
+++ b/templates/commit-lint.yml
@@ -1,0 +1,72 @@
+spec:
+  inputs:
+    stage:
+      description: The pipeline stage where to do the commit lint
+      default: test
+    runner:
+      description: GitLab CI runner tag
+      default: hetzner-amd-beefy
+    registry:
+      description: Container images registry
+      default: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}
+    commitlint-tag:
+      description: Tag for container image docker.io/commitlint/commitlint
+      default: latest
+---
+
+lint:commit:
+  stage: $[[ inputs.stage ]]
+  tags:
+    - $[[ inputs.runner ]]
+  needs: []
+  image:
+    name: $[[ inputs.registry ]]/commitlint/commitlint:$[[ inputs.commitlint-tag ]]
+    entrypoint: [""]
+  rules:
+    # Exclude production branches
+    - if: $CI_COMMIT_BRANCH =~ "/^(master|main|hosted|staging|production)$/"
+      when: never
+    # Exclude maintenance branches
+    - if: $CI_COMMIT_BRANCH =~ "/^([0-9]+\.[0-9]+\.x|v[0-9]+\.[0-9]+\.x)$/"
+      when: never
+    # Exclude tags
+    - if: $CI_COMMIT_TAG
+      when: never
+    # Run for every other case
+    - when: always
+  variables:
+    GIT_STRATEGY: clone # clone entire repo instead of reusing workspace
+    GIT_DEPTH: 0 # avoid shallow clone, this test requires full git history
+  before_script:
+    # Some projects use selective-scope plugin
+    - npm install --global commitlint-plugin-selective-scope
+    # Move away from the current branch and fetch all directly to local branches
+    - git branch --move temp-branch || true
+    - git fetch --force origin 'refs/heads/*:refs/heads/*'
+    - git fetch --tags origin
+    # Fetch generic rules if the project does not have its own
+    - if [ ! -f commitlint.config.js ]; then
+    -   apk add --no-cache curl
+    -   curl --fail --output commitlint.config.js
+          https://raw.githubusercontent.com/mendersoftware/mendertesting/master/commitlint.config.js
+    - fi
+  script:
+    # We are running GitLab CI from our custom pr_XXX branches, not associated
+    # to GitLab Merge Requests. Reconstruct the correct range from the current
+    # branch by excluding all other branches.
+    - EXCLUDE_LIST=$(mktemp)
+    - EXCLUDE_LIST_REMOVE=$(mktemp)
+    - git for-each-ref --format='%(refname)' | sort > $EXCLUDE_LIST
+    - git for-each-ref --format='%(refname)' --points-at $CI_COMMIT_REF_NAME | sort > $EXCLUDE_LIST_REMOVE
+    - TO_EXCLUDE="$(comm -23 $EXCLUDE_LIST $EXCLUDE_LIST_REMOVE | tr '\n' ' ')"
+    - COMMIT_RANGE="$CI_COMMIT_REF_NAME --not $TO_EXCLUDE"
+    - rm -f $EXCLUDE_LIST $EXCLUDE_LIST_REMOVE
+    # Ready to lint \o/
+    - 'echo "Checking range ${COMMIT_RANGE}:"'
+    - git --no-pager log $COMMIT_RANGE
+    - ret=0; touch commitlint.log
+    - for commit in $(git rev-list --no-merges $COMMIT_RANGE); do
+    -   git show $commit --no-patch --format=%B | commitlint >>commitlint.log || ret=$?
+    - done
+    - cat commitlint.log
+    - test $ret -eq 0


### PR DESCRIPTION
The template uses `commitlint` to lint every commit that is unique to the current branch. The Git logic is a bit cumbersome, but due to our GitHub<->GitLab sync we don't have info on the base branch for the branch being tested.