### PR TITLE
fix: Prevent brew builds from waiting for input

### DIFF
--- a/templates/brew-build.yml
+++ b/templates/brew-build.yml
@@ -53,7 +53,7 @@ $[[ inputs.stage ]]:build:brew:
     - |
         gsed -e /sha256/d -e "/url /s|\".*\"|\"https://github.com/mendersoftware/${REPO}.git\",|" -e "/url \"https/a\ \ \ \ revision: \"${CI_COMMIT_SHA}\",\n    using: GitHubPRDownloadStrategy\n  version \"1234\"" < ${FORMULA_NAME}_upstream.rb >> $FORMULA_FILE
     # 4. run brew build and test
-    - HOMEBREW_NO_INSTALL_FROM_API=1 brew reinstall --build-from-source --verbose --debug --formula ./${FORMULA_FILE}
+    - HOMEBREW_NO_INSTALL_FROM_API=1 brew reinstall --build-from-source --verbose --debug --formula ./${FORMULA_FILE} < /dev/null
     - brew test ./${FORMULA_FILE}
   after_script:
     - FORMULA_FILE="$(basename $[[ inputs.formula ]])"


### PR DESCRIPTION
Otherwise it can make the CI job stuck and doomed to time out (in 1 hour). On top of that, timed-out jobs don't seem to run `after_script` so temporary directories can be left in place.

Ticket: MEN-8331
Changelog: none