### PR TITLE
chore: Switched to sentence case in changelog headings

### DIFF
--- a/utils/cliff.toml
+++ b/utils/cliff.toml
@@ -96,7 +96,7 @@ commit_parsers = [
     { message = "^chore: bump", group = "Security" },
     { message = "^test", group = "Testing", skip = true },
     { message = "^feat", group = "Features" },
-    { message = "^fix", group = "Bug Fixes" },
+    { message = "^fix", group = "Bug fixes" },
     { message = "^doc", group = "Documentation" },
     { message = "^perf", group = "Performance" },
     { message = "^refactor", group = "Refactor" },

--- a/utils/cliff.toml.scoped
+++ b/utils/cliff.toml.scoped
@@ -102,7 +102,7 @@ commit_parsers = [
     { message = "^chore: bump", group = "Security" },
     { message = "^test", group = "Testing", skip = true },
     { message = "^feat", group = "Features" },
-    { message = "^fix", group = "Bug Fixes" },
+    { message = "^fix", group = "Bug fixes" },
     { message = "^doc", group = "Documentation" },
     { message = "^perf", group = "Performance" },
     { message = "^refactor", group = "Refactor" },


### PR DESCRIPTION
See:
https://github.com/mendersoftware/mender-server-enterprise/pull/546
