### PR TITLE
fix: Ignore `brew remove` failing in brew build cleanup

### DIFF
--- a/templates/brew-build.yml
+++ b/templates/brew-build.yml
@@ -58,5 +58,5 @@ $[[ inputs.stage ]]:build:brew:
   after_script:
     - FORMULA_FILE="$(basename $[[ inputs.formula ]])"
     - FORMULA_NAME="${FORMULA_FILE%%.*}"
-    - brew remove $FORMULA_NAME
+    - brew remove $FORMULA_NAME || true
     - rm -rf "/tmp/brew_build_${CI_PIPELINE_ID}"


### PR DESCRIPTION
We want to run all the steps in `after_script` and `brew remove WHATEVER` can easily fail if the job actually failed to build or install the thing.

Ticket: MEN-8331
Changelog: none