### PR TITLE
chore: upgrade debian image used in ci to bookworm

### DIFF
--- a/.gitlab-ci-check-docker-deploy.yml
+++ b/.gitlab-ci-check-docker-deploy.yml
@@ -57,7 +57,7 @@ sync:image:
   dependencies:
     - publish:image
   stage: sync
-  image: debian:buster
+  image: debian:bookworm
   before_script:
     - apt update && apt install -yyq git
     # Prepare SSH key


### PR DESCRIPTION
- upgrades the now very EOL `debian:buster` image used in gitlabci to `debian:bookworm`