### PR TITLE
feat: component to add workstation-tools-repository

### DIFF
--- a/templates/workstation-tools-repository.yml
+++ b/templates/workstation-tools-repository.yml
@@ -1,0 +1,42 @@
+spec:
+  inputs:
+    repo_channel:
+      description: Which channel of the repository to use. Use `experimental` to get bleeding edge version of the tools, otherwise use `stable`.
+      default: stable
+---
+
+variables:
+  WORKSTATION_TOOLS_REPOSITORY_DISTRO_ID: ""
+  WORKSTATION_TOOLS_REPOSITORY_REPO_CHANNEL: ""
+  WORKSTATION_TOOLS_REPOSITORY_DISTRO_VERSION_CODENAME: ""
+  WORKSTATION_TOOLS_EXPECTED_GPG_FINGERPRINT: E6C857345575F9218396566224072B80A1B29B00
+
+# This can also be directly used in files that include this component with '!reference [.add_workstation_tools_repository]'
+.add_workstation_tools_repository: &add_workstation_tools_repository
+    # Get default values
+    - id=$(grep -E '^ID=' /etc/os-release | cut -d'=' -f2)
+    - version_codename=$(grep -E '^VERSION_CODENAME=' /etc/os-release | cut -d'=' -f2)
+    # The WORKSTATION_TOOLS_REPOSITORY_* variables take precedence
+    - distro_id=${WORKSTATION_TOOLS_REPOSITORY_DISTRO_ID:-$id}
+    - distro_version_codename=${WORKSTATION_TOOLS_REPOSITORY_DISTRO_VERSION_CODENAME:-$version_codename}
+    - repo_channel=${WORKSTATION_TOOLS_REPOSITORY_REPO_CHANNEL:-$[[ inputs.repo_channel ]]}
+    # Add repo
+    - apt-get update --assume-yes
+    - apt-get install --assume-yes curl gpg
+    - curl -fsSL https://downloads.mender.io/repos/debian/gpg | tee /etc/apt/trusted.gpg.d/mender.asc
+    - gpg --show-keys --with-fingerprint --with-colons /etc/apt/trusted.gpg.d/mender.asc | grep -E "fpr:::::::::$WORKSTATION_TOOLS_EXPECTED_GPG_FINGERPRINT:" || exit 1
+    - echo "deb [arch=amd64] https://downloads.mender.io/repos/workstation-tools $distro_id/$distro_version_codename/$repo_channel main" \
+            | tee /etc/apt/sources.list.d/mender.list
+    - apt-get update --assume-yes
+
+# You can install mender-artifact by including this component and calling `!reference [.install_mender_artifact]`
+# This will install the latest available mender-artifact version in the workstation-tools repo
+.install_mender_artifact:
+  - *add_workstation_tools_repository
+  - apt-get --assume-yes install mender-artifact
+
+# You can install mender-cli by including this component and calling `!reference [.install_mender_cli]`
+# This will install the latest available mender-cli version in the workstation-tools repo
+.install_mender_cli:
+  - *add_workstation_tools_repository
+  - apt-get --assume-yes install mender-cli


### PR DESCRIPTION
Originally i wanted it to be a template which you extended, but that didn't work due to possible override of `before_script`. I instead made it an anchor, but to use that in files that include the component you can't do the regular `*add_workstation_tools_repository` so you need to use `!reference` https://docs.gitlab.com/ci/yaml/yaml_optimization/#reference-tags 

To use this you must include the component and then you could either do:
```
- !reference [.install_mender_artifact]`
```
or 
```  
- !reference [.add_workstation_tools_repository]
- apt-get install -y mender-artifact
```