### PR TITLE
chore: set `HOMEBREW_DEVELOPER=1` in build-brew component

### DIFF
--- a/templates/brew-build.yml
+++ b/templates/brew-build.yml
@@ -18,6 +18,8 @@ $[[ inputs.stage ]]:build:brew:
   tags:
     - $[[ inputs.runner ]]
   needs: []
+  variables:
+    HOMEBREW_DEVELOPER: 1
   rules:
     # Manually run job. Note that this variable is not shown by default
     # in the pipelines that include this component.


### PR DESCRIPTION
Set HOMEBREW_DEVELOPER to 1 to ensure that we're able to install local formulas.

For some reason the mender-artifact test:build-brew job started failing, https://gitlab.com/Northern.tech/Mender/mender-artifact/-/jobs/11045022868

Explicitly setting HOMEBREW_DEVELOPER=1 fixes the issues. I tested a pipeline using this branch here, https://gitlab.com/Northern.tech/Mender/mender-artifact/-/jobs/11045066850