### PR TITLE
QA-1160: Add GitLab CI/CD component documentation and 3C Release Process

### DIFF
--- a/templates/README.3CRelease.md
+++ b/templates/README.3CRelease.md
@@ -1,0 +1,131 @@
+# Click Click Click Release Process
+
+<!-- Last updated: 2025-09-23 -->
+
+## Introduction
+
+The Click Click Click release process aims to provide a lightweight and modular release workflow through GitLab CI/CD components. The process is designed to be flexible and adapt to different types of components being released.
+
+**Common release actions** (applicable to all components):
+- Changelog updates
+- Mender documentation version updates
+- License manifest generation
+- Atlassian Compass deployment tracking
+- JIRA version release
+
+**Component-specific actions** (depending on the nature of what's being released):
+- **Binary distribution packages** (.deb, .rpm) for system-level tools
+- **Container images** for containerized applications
+- **Yocto recipes** for embedded system components
+
+## Process
+
+### 🔍 First Click: Check Requirements
+Before initiating a release, verify that all prerequisites are met:
+- **No JIRA blockers** - Ensure no critical issues prevent the release
+- **Team alignment** - No concerns raised during team meetings or stand-ups
+- **Green pipelines** - All related CI/CD pipelines are green. The release will be triggered from the main branch
+
+### 🧨 Second Click: Run the Show
+Execute the release preparation and validation:
+- **Review and merge Release Candidate** Review generated changelog PR `https://github.com/mendersoftware/<reposistory>/pulls?q=is%3Apr+is%3Aopen+label%3A%22autorelease%3A+pending%22`
+- **Tag and publish the Release** - Trigger the manual job from `https://gitlab.com/Northern.tech/Mender/<reposistory>/-/jobs?statuses=MANUAL`
+
+### 📦 Third Click: Deliver It
+Review that all the Git-tag triggered actions complete successfully:
+- **GitHub Release** - Verify that the Git tag and GitHub release were done
+- **Automated Pull Requests** - Review and merge PRs for Mender Docs, changelogs, etc
+- **Technical deliverables** - Verify the deliverables: Container images, binary packages, Yocto recipes
+- **Documentation updates** - Verify the formalities: Mender Docs updated, JIRA version released, changelogs published, license manifest published
+- **Communication** - Inform stakeholders and celebrate with pizza 🍕
+- **Follow-up** - Monitor and assist downstream repositories that consume the release
+
+## ASCII Flow Diagram
+
+```
+┌──────────────────┐
+│  CI/CD Pipeline  │
+│    Build, Test   │ ──┐
+│       ...        │   │
+│  (main branch)   │   │
+└──────────────────┘   │
+                       ▼
+              ┌────────────┐                        ┌────────────────┐
+              │ Release    │         Click,         │                │
+              │ Candidate  │ ──────> Click, ──────> │ Git tag +      │
+              │            │         Click!         │ GitHub Release │
+              └────────────┘                        └────┬───────────┘
+                                                         │
+                                                         ▼
+                                         ╔════════════════════════════════╗
+                                         ║ 🔵 Common Release Actions      ║
+                                         ║     (always executed)          ║
+                                         ╠════════════════════════════════╣
+                                         ║   Changelog                    ║──→ PR in mender-docs-changelog
+                                         ║   release-docs-changelog.yml   ║
+                                         ╟────────────────────────────────╢
+                                         ║   Mender Docs version          ║──→ PR in mender-docs (version update)
+                                         ║   release-mender-docs.yml      ║
+                                         ╟────────────────────────────────╢
+                                         ║   License manifest             ║──→ PR in mender-docs (license manifest update)
+                                         ║   release-oslicenses-golang.yml║
+                                         ║   TODO QA-1212                 ║
+                                         ║   release-oslicenses-generic.yml ║
+                                         ╟────────────────────────────────╢
+                                         ║   Atlassian Compass            ║──→ Deployment tracking updated
+                                         ║   release-compass.yml          ║
+                                         ╟────────────────────────────────╢
+                                         ║   JIRA version release         ║──→ All tickets mentioned ini the changelog marked with fixVersion
+                                         ║   TODO QA-1211                 ║
+                                         ║   release-jira-versions.yml    ║
+                                         ╚════════════════════════════════╝
+                                                  ║
+                                                  ▼
+                                         ╔════════════════════════════════╗
+                                         ║ 🟡 Component-Specific Actions  ║
+                                         ║      (optional/conditional)    ║
+                                         ╠════════════════════════════════╣
+                                         ║   Dist packages                ║──→ .deb, packages
+                                         ║   release-dist-packages.yml    ║
+                                         ╟────────────────────────────────╢
+                                         ║   Container Image              ║──→ Images in Container Image Registry (Docker Hub, Mender Registry)
+                                         ║   TODO QA-1183                 ║
+                                         ║   release-container-images.yml ║
+                                         ╟────────────────────────────────╢
+                                         ║   Yocto recipe                 ║──→ PR in meta-mender
+                                         ║   TODO QA-1213                 ║
+                                         ║   release-yocto-recipe.yml     ║
+                                         ╚════════════════════════════════╝
+                                                  │
+                                                  ▼
+                                         ╔════════════════════════════════╗
+                                         ║ 👤 Manual steps                ║
+                                         ╠════════════════════════════════╣
+                                         ║ 🟡 Submit PR to                ║──→ Updated formula in homebrew-core
+                                         ║    Homebrew/homebrew-core      ║
+                                         ╚════════════════════════════════╝
+                                                  │
+                                                  ▼
+                                         ┌─────────────────────────┐
+                                         │ 🍕 Pizza celebration 🍕 │
+                                         └─────────────────────────┘
+```
+
+## Component Status
+
+### Implemented Components
+- **release-candidate.yml** - Creates release using release-please (the "Click Click Click" part)
+- **release-mender-docs.yml** - Updates component versions in mender-docs
+- **release-docs-changelog.yml** - Updates changelog in mender-docs-changelog
+- **release-dist-packages.yml** - Triggers distribution package builds
+- **release-compass.yml** - Updates Atlassian Compass deployment tracking
+- **release-oslicenses-golang.yml** - Generates and publishes Open Source license manifest for Go projects
+
+### TODO Components
+- **release-oslicenses-generic.yml** - Generic license manifest generation (TODO QA-1212)
+- **release-jira-versions.yml** - Automatically mark JIRA tickets with fixVersion (TODO QA-1211)
+- **release-yocto-recipe.yml** - Update Yocto recipes with new version (TODO QA-1213)
+- **release-container-images.yml** - Publish container images to registries (TODO QA-1183)
+
+### 👤 Manual Steps
+- **Homebrew formula submission** - Submit PR to Homebrew/homebrew-core with updated formula

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,158 @@
+# GitLab CI/CD Components for Mender
+
+<!-- Last updated: 2025-09-23 -->
+
+This directory contains reusable GitLab CI/CD components for Mender projects. These components streamline common CI/CD tasks and implement the standardized release process.
+
+## What are GitLab CI/CD Components?
+
+GitLab CI/CD components are reusable pipeline configurations that can be shared across projects. They provide:
+- **Modularity**: Break complex pipelines into manageable, reusable pieces
+- **Consistency**: Ensure uniform CI/CD practices across all Mender projects
+- **Versioning**: Use semantic versioning for controlled updates
+- **Input validation**: Define required and optional inputs with defaults and descriptions
+
+For comprehensive documentation, see the [official GitLab CI/CD Components documentation](https://docs.gitlab.com/ci/components/).
+
+## Available Components
+
+### Helper Components
+
+#### commit-lint
+Validates commit messages against conventional commit format using commitlint. A default commitlint config is fetched if the repo does not provide its own.
+
+**Usage:**
+```yaml
+include:
+  - component: $CI_SERVER_FQDN/Northern.tech/Mender/mendertesting/commit-lint@~latest
+    inputs:
+      stage: test  # optional, default: test
+      runner: hetzner-amd-beefy  # optional
+```
+
+#### brew-build
+Tests Homebrew formula builds on macOS runners. Builds from source using current commit and runs brew test.
+
+**Usage:**
+```yaml
+include:
+  - component: $CI_SERVER_FQDN/Northern.tech/Mender/mendertesting/brew-build@~latest
+    inputs:
+      formula: m/mender-artifact.rb  # required
+      repo: mender-artifact  # optional, defaults to formula name
+```
+
+### Release Process Components (Click Click Click)
+
+The Click Click Click (CCC) release process provides automated, consistent releases across all Mender components.
+
+**Note:** Release components require environment variables that are already configured at the GitLab Mender group level:
+- `GITHUB_BOT_TOKEN_REPO_FULL` - GitHub token with repository access
+- `GITHUB_CLI_TOKEN` - GitHub CLI authentication token
+- `COMPASS_JIRA_USER` - Atlassian Jira username (for release-compass)
+- `COMPASS_JIRA_API_TOKEN` - Atlassian Jira API token (for release-compass)
+
+#### release-candidate
+Creates and manages release candidates using release-please and git-cliff for changelog generation.
+
+**Usage:**
+```yaml
+include:
+  - component: $CI_SERVER_FQDN/Northern.tech/Mender/mendertesting/release-candidate@~latest
+    inputs:
+      github_repo: mendersoftware/mender-artifact  # required
+```
+
+#### release-compass
+Updates Atlassian Compass deployment tracking when a release is published.
+
+**Usage:**
+```yaml
+include:
+  - component: $CI_SERVER_FQDN/Northern.tech/Mender/mendertesting/release-compass@~latest
+    inputs:
+      compass_component_id: 12345abcd...  # required, find in Compass URL
+```
+
+#### release-dist-packages
+Triggers distribution package builds in the mender-dist-packages repository. Validates package name against mender-dist-packages variables.
+
+**Usage:**
+```yaml
+include:
+  - component: $CI_SERVER_FQDN/Northern.tech/Mender/mendertesting/release-dist-packages@~latest
+    inputs:
+      package: MENDER_ARTIFACT  # required, uppercase package name
+      test-mender-dist-packages: true  # optional, default: true
+      publish-mender-dist-packages: true  # optional, default: true
+```
+
+#### release-docs-changelog
+Updates changelog documentation in the mender-docs-changelog repository. Requires `.docs_header.md` and `CHANGELOG.md` in source repo.
+
+**Usage:**
+```yaml
+include:
+  - component: $CI_SERVER_FQDN/Northern.tech/Mender/mendertesting/release-docs-changelog@~latest
+    inputs:
+      remote_changelog_file: 30.mender-artifact/docs.md  # required
+```
+
+#### release-mender-docs
+Updates component versions in the mender-docs repository using the autoversion.py script.
+
+**Usage:**
+```yaml
+include:
+  - component: $CI_SERVER_FQDN/Northern.tech/Mender/mendertesting/release-mender-docs@~latest
+    inputs:
+      component: mender-artifact  # required
+```
+
+#### release-oslicenses-golang
+Generates and publishes Open Source license manifest for Go projects. Scans dependencies and creates license information for compliance purposes.
+
+**Usage:**
+```yaml
+include:
+  - component: $CI_SERVER_FQDN/Northern.tech/Mender/mendertesting/release-oslicenses-golang@~latest
+    inputs:
+      github_repo: mendersoftware/mender-artifact  # required
+```
+
+## Other Components
+
+The following components are currently not in use.
+- `workstation-tools-repository.yml` - Source-able code to install workstation tools
+- `device-components-repository.yml` - Source-able code to install device components
+
+
+## Example: Complete Release Setup
+
+Here's a complete example of setting up the Click Click Click release process for a component (from mender-artifact):
+
+```yaml
+# .gitlab-ci.yml
+include:
+  # Release CI/CD components
+  - component: $CI_SERVER_FQDN/Northern.tech/Mender/mendertesting/release-candidate@~latest
+    inputs:
+      github_repo: mendersoftware/mender-artifact
+  - component: $CI_SERVER_FQDN/Northern.tech/Mender/mendertesting/release-mender-docs@~latest
+    inputs:
+      component: mender-artifact
+  - component: $CI_SERVER_FQDN/Northern.tech/Mender/mendertesting/release-dist-packages@~latest
+    inputs:
+      package: MENDER_ARTIFACT
+  - component: $CI_SERVER_FQDN/Northern.tech/Mender/mendertesting/release-compass@~latest
+    inputs:
+      compass_component_id: abc123-your-component-id-here
+  - component: $CI_SERVER_FQDN/Northern.tech/Mender/mendertesting/release-oslicenses-golang@~latest
+    inputs:
+      github_repo: mendersoftware/mender-artifact
+
+stages:
+  - test
+  - publish
+```
+


### PR DESCRIPTION
Add comprehensive documentation for Mender's GitLab CI/CD components including helper components, release process components, and the Click Click Click release workflow.

The ASCII flow diagram is the result of my human hand-drawn sketch going through AI-powered beautifications.