### PR TITLE
ci: Fix rules order for adding `release:golanglicenses:generate` CI job

### DIFF
--- a/templates/release-oslicenses-golang.yml
+++ b/templates/release-oslicenses-golang.yml
@@ -27,10 +27,10 @@ release:golanglicenses:generate:
   tags:
     - $[[ inputs.runner ]]
   rules:
+    - if: '$CI_COMMIT_REF_PROTECTED == "true"'
     - changes:
         paths: ["**/*"]
         compare_to: $DEFAULT_BRANCH
-    - if: '$CI_COMMIT_REF_PROTECTED == "true"'
   image: golang:$[[ inputs.golang_version ]]
   needs: []
   variables:

--- a/templates/release-oslicenses-golang.yml
+++ b/templates/release-oslicenses-golang.yml
@@ -31,7 +31,6 @@ release:golanglicenses:generate:
         paths: ["**/*"]
         compare_to: $DEFAULT_BRANCH
     - if: '$CI_COMMIT_REF_PROTECTED == "true"'
-      when: on_success
   image: golang:$[[ inputs.golang_version ]]
   needs: []
   variables:
@@ -47,7 +46,6 @@ release:golanglicenses:generate:
     - go-licenses check --disallowed_types=forbidden,restricted,unknown --ignore=github.com/mendersoftware/$CI_PROJECT_NAME ./...
     - go-licenses report --template=./go-licenses.gotpl --ignore=github.com/mendersoftware/$CI_PROJECT_NAME ./... > licenses.md
   artifacts:
-    when: on_success
     expire_in: "1w"
     paths:
       - licenses.md


### PR DESCRIPTION
Otherwise on actual tags (protected refs) the job is not added because there are no changes to the default branch