### PR TITLE
ci: Adjust and align PR titles and bodies for two components

### DIFF
--- a/templates/release-docs-changelog.yml
+++ b/templates/release-docs-changelog.yml
@@ -70,5 +70,9 @@ release:mender-docs-changelog:
     - git add $[[ inputs.remote_changelog_file ]]
     - 'git commit -s -m "chore: add $CI_PROJECT_NAME changelog"'
     - git push origin changelog-${CI_JOB_ID}
-    - gh pr create --title "Update CHANGELOG.md for $CI_PROJECT_NAME" --body "Automated change to the CHANGELOG.md file" --base master --head changelog-${CI_JOB_ID}
-
+    - gh pr create
+      --title "Update changelog for ${CI_PROJECT_NAME} ${CI_COMMIT_TAG}"
+      --body "Automated change to $[[ inputs.remote_changelog_file ]]"
+      --base master
+      --head changelog-${CI_JOB_ID}
+# TODO something similar to the license

--- a/templates/release-oslicenses-golang.yml
+++ b/templates/release-oslicenses-golang.yml
@@ -101,4 +101,8 @@ release:golanglicenses:publish:
     - |
       git commit -s -m "chore: add $CI_PROJECT_NAME open source licenses"
     - git push origin licenses-${CI_JOB_ID}
-    - gh pr create --title "${CI_COMMIT_TAG} Release - update $CI_PROJECT_NAME licenses" --body "Automated change to the $CI_PROJECT_NAME Licenses during ${CI_COMMIT_TAG} release" --base master --head licenses-${CI_JOB_ID}
+    - gh pr create
+      --title "Update OS licenses manifest for ${CI_PROJECT_NAME} ${CI_COMMIT_TAG}"
+      --body "Automated change to $[[ inputs.remote_license_file ]]"
+      --base master
+      --head licenses-${CI_JOB_ID}


### PR DESCRIPTION
These two components do something very similar, but they were using different messaging. Additionally the changelog one was mentioning `CHANGELOG.md` which does not exist.