### PR TITLE
ci: Compare changes against branch using predefined variable

### DIFF
--- a/templates/release-oslicenses-golang.yml
+++ b/templates/release-oslicenses-golang.yml
@@ -30,7 +30,7 @@ release:golanglicenses:generate:
     - if: '$CI_COMMIT_REF_PROTECTED == "true"'
     - changes:
         paths: ["**/*"]
-        compare_to: $DEFAULT_BRANCH
+        compare_to: $CI_DEFAULT_BRANCH
   image: golang:$[[ inputs.golang_version ]]
   needs: []
   variables:


### PR DESCRIPTION
Instead of relying on the user of the CI/CD component defining an explicit variable. Using the pre-defined one is more robust and follows other templates.