### PR TITLE
fix: Update sleep period in changelog creation

### DIFF
--- a/templates/release-candidate.yml
+++ b/templates/release-candidate.yml
@@ -73,7 +73,7 @@ release:candidate:update-changelog:
       --target-branch=${CI_COMMIT_REF_NAME} || echo "INFO - release already exists"
     # Tiny sleep to avoid race condition:
     # The PR just created by release-please takes some time to be listed by GitHub API
-    - sleep 5
+    - sleep 10
     - RELEASE_PLEASE_PR=$(gh pr list --author "$[[ inputs.github_user_name ]]" --head "release-please--branches--${CI_COMMIT_REF_NAME}" --json number | jq -r '.[0].number // empty')
     - if [ -n "$RELEASE_PLEASE_PR" ]; then
     -   cp CHANGELOG.md CHANGELOG.md.${CI_COMMIT_SHA}


### PR DESCRIPTION
release:candidate:update-changelog shall run after release:candidate:tag-and-release job is completed.