### PR TITLE
chore: migrate golangci-lint to v2

### DIFF
--- a/.gitlab-ci-check-golang-lint.yml
+++ b/.gitlab-ci-check-golang-lint.yml
@@ -23,7 +23,7 @@ variables:
   IMAGE_GOLANGCI_VERSION:
     description: |-
       Container image tag of golangci/golangci-lint used for static checks.
-    value: "v1.64.7"
+    value: "v2.11.4"
 
 test:static:
   tags:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,5 @@
+version: "2"
+
 run:
   # timeout for analysis, e.g. 30s, 5m, default is 1m
   timeout: 5m
@@ -9,38 +11,51 @@ run:
   # If false (default) - golangci-lint acquires file lock on start.
   allow-parallel-runners: true
 
-issues:
-  # Enables exclude of directories:
-  # vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
-  exclude-dirs-use-default: true
-
 linters:
   enable:
     - bodyclose
     - errcheck
     - gocyclo
-    - gofmt
-    - goimports
-    - gosimple
     - govet
     - ineffassign
     - lll
     - staticcheck
-    - typecheck
     - unused
 
-linters-settings:
-  gocyclo:
-    # default is 30.
-    min-complexity: 20
+  exclusions:
+    # Equivalent to issues.exclude-use-default in v1.
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
 
-  goimports:
-    # to be edited by the template
-    local-prefixes:
-      "github.com/mendersoftware/#CI_PROJECT_NAME#"
+  settings:
+    gocyclo:
+      # default is 30.
+      min-complexity: 20
 
-  lll:
-    # max line length, lines longer will be reported. Default is 120.
-    line-length: 100
-    # tab width in spaces. Default to 1.
-    tab-width: 4
+    staticcheck:
+      checks:
+        - "all"
+        # ST (stylecheck) and QF (quickfix) were not enabled in v1;
+        # exclude them to avoid breaking existing repos on upgrade.
+        - "-ST*"
+        - "-QF*"
+
+    lll:
+      # max line length, lines longer will be reported. Default is 120.
+      line-length: 100
+      # tab width in spaces. Default to 1.
+      tab-width: 4
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
+
+  settings:
+    goimports:
+      # to be edited by the template
+      local-prefixes:
+        - "github.com/mendersoftware/#CI_PROJECT_NAME#"


### PR DESCRIPTION
I merged https://github.com/mendersoftware/mendertesting/pull/460 into the branch I was testing stuff on rather than master.