### PR TITLE
chore: extract golang version for `test:unit` to variable

### DIFF
--- a/.gitlab-ci-check-golang-unittests-v2.yml
+++ b/.gitlab-ci-check-golang-unittests-v2.yml
@@ -22,6 +22,8 @@ test:unit:
     GIT_STRATEGY: clone # clone entire repo instead of reusing workspace
     GIT_DEPTH: 0 # avoid shallow clone, this test requires full git history
     TEST_MONGO_URL: "mongodb://mongo"
+    GO_VERSION: "1.24"
+
   tags:
     - mender-qa-worker-generic-light
   stage: test
@@ -33,7 +35,7 @@ test:unit:
       - stuck_or_timeout_failure
   except:
     - /^saas-[a-zA-Z0-9.]+$/
-  image: golang:1.24
+  image: golang:${GO_VERSION}
   services:
     - "mongo:${MONGO_VERSION}"
   before_script:


### PR DESCRIPTION
This allows jobs to override the golang version if needed.