### PR TITLE
ci: Bump golang image for test:static

### DIFF
--- a/.gitlab-ci-check-golang-static.yml
+++ b/.gitlab-ci-check-golang-static.yml
@@ -27,7 +27,7 @@ test:static:
   needs: []
   except:
     - /^saas-[a-zA-Z0-9.]+$/
-  image: golang:1.20
+  image: golang:1.22
   before_script:
     - !reference [.qa-common-network-go-retry, before_script]
     - !reference [.qa-common-network-apt-retry, before_script]


### PR DESCRIPTION
Test static is useing and external dependency which requires image to be at least `golang:1.22`