### PR TITLE
ci: replace Coveralls with Codecov for acceptance coverage

### DIFF
--- a/.gitlab-ci-check-docker-acceptance.yml
+++ b/.gitlab-ci-check-docker-acceptance.yml
@@ -20,7 +20,7 @@
 #     file: '.gitlab-ci-check-docker-acceptance.yml'
 #
 # Requires the following variables set in the project CI/CD settings:
-#   COVERALLS_TOKEN: Token from coveralls.io for this repository
+#   CODECOV_TOKEN: Token from codecov.io for this repository
 #
 # If the tests require access to Mender Registry hosted images, it
 # will require also the following vabiables:
@@ -128,7 +128,7 @@ test:acceptance_tests:
 
 publish:acceptance:
   tags:
-    - mender-qa-worker-generic-light
+    - k8s-small
   stage: publish
   needs:
     - job: test:acceptance_tests
@@ -137,43 +137,12 @@ publish:acceptance:
     - if: '$CI_COMMIT_TAG =~ /^saas-[a-zA-Z0-9.]+$/'
       when: never
     - when: on_success
-  image: golang:1.20-alpine3.17
-  allow_failure: true
-  before_script:
-    # Install dependencies
-    - apk add --no-cache git
-    - go install github.com/mattn/goveralls@latest
-    # Prepare GOPATH
-    - mkdir -p /go/src/github.com/mendersoftware
-    - cp -r ${CI_PROJECT_DIR} /go/src/github.com/mendersoftware/${CI_PROJECT_NAME}
-    - cd /go/src/github.com/mendersoftware/${CI_PROJECT_NAME}
-    # Coveralls env variables:
-    #  According to https://docs.coveralls.io/ci-services
-    #  we should set CI_NAME, CI_BUILD_NUMBER, etc. But according
-    #  to goveralls source code (https://github.com/mattn/goveralls)
-    #  many of these are not supported. Set CI_BRANCH
-    #  and pass few others as command line arguments.
-    #  See also https://docs.coveralls.io/api-introduction
-    - export CI_BRANCH=${CI_COMMIT_BRANCH}
-  script:
-    - goveralls
-      -repotoken ${COVERALLS_TOKEN}
-      -service gitlab-ci
-      -jobid $CI_PIPELINE_ID
-      -covermode set
-      -flagname acceptance
-      -parallel
-      -coverprofile ./tests/coverage-acceptance.txt
-
-coveralls:finish-build:
-  tags:
-    - mender-qa-worker-generic-light
-  stage: .post
-  # See https://docs.coveralls.io/api-parallel-build-webhook
-  variables:
-    COVERALLS_WEBHOOK_URL: "https://coveralls.io/webhook"
-    COVERALLS_RERUN_BUILD_URL: "https://coveralls.io/rerun_build"
   image: curlimages/curl-base
+  allow_failure: true
   script:
-    - 'curl -k ${COVERALLS_WEBHOOK_URL}?repo_token=${COVERALLS_TOKEN} -d "payload[build_num]=$CI_PIPELINE_ID&payload[status]=done"'
-    - 'curl -k "${COVERALLS_RERUN_BUILD_URL}?repo_token=${COVERALLS_TOKEN}&build_num=${CI_PIPELINE_ID}"'
+    - curl -Os https://uploader.codecov.io/latest/linux/codecov
+    - chmod +x codecov
+    - ./codecov --token ${CODECOV_TOKEN} --file ./tests/coverage-acceptance.txt --flag acceptance --nonZero
+      --slug mendersoftware/${CI_PROJECT_NAME}
+      --pr $(echo "${CI_COMMIT_BRANCH}" | sed 's/^pr_//')
+      --service github

--- a/.gitlab-ci-check-golang-unittests-v2.yml
+++ b/.gitlab-ci-check-golang-unittests-v2.yml
@@ -10,7 +10,7 @@
 #     file: '.gitlab-ci-check-golang-unittests-v2.yml'
 #
 # Requires the following variables set in the project CI/CD settings:
-#   COVERALLS_TOKEN: Token from coveralls.io for this repository
+#   CODECOV_TOKEN: Token from codecov.io for this repository
 #
 stages:
   - test
@@ -63,7 +63,7 @@ test:unit:
 
 publish:unittests:
   tags:
-    - mender-qa-worker-generic-light
+    - k8s-small
   stage: publish
   allow_failure: true
   retry:
@@ -71,45 +71,17 @@ publish:unittests:
     when:
       - runner_system_failure
       - stuck_or_timeout_failure
-  except:
-    - /^saas-[a-zA-Z0-9.]+$/
-  image: golang:1.23.4
+  rules:
+    - if: '$CI_COMMIT_TAG =~ /^saas-[a-zA-Z0-9.]+$/'
+      when: never
+    - when: on_success
+  image: curlimages/curl-base
   dependencies:
     - test:unit
-  before_script:
-    - !reference [.qa-common-network-go-retry, before_script]
-    # Install dependencies
-    - go install github.com/mattn/goveralls@v0.0.12
-    # Coveralls env variables:
-    #  According to https://docs.coveralls.io/ci-services
-    #  we should set CI_NAME, CI_BUILD_NUMBER, etc. But according
-    #  to goveralls source code (https://github.com/mattn/goveralls)
-    #  many of these are not supported. Set CI_BRANCH,
-    #  and pass few others as command line arguments.
-    #  See also https://docs.coveralls.io/api-introduction
-    - export CI_BRANCH=${CI_COMMIT_BRANCH}
   script:
-    - goveralls
-      -coverprofile coverage.txt
-      -service gitlab-ci
-      -jobid $CI_PIPELINE_ID
-      -flagname unittests
-      -parallel
-
-coveralls:finish-build:
-  tags:
-    - mender-qa-worker-generic-light
-  stage: .post
-  # See https://docs.coveralls.io/api-parallel-build-webhook
-  variables:
-    COVERALLS_WEBHOOK_URL: "https://coveralls.io/webhook"
-    COVERALLS_RERUN_BUILD_URL: "https://coveralls.io/rerun_build"
-  retry:
-    max: 2
-    when:
-      - runner_system_failure
-      - stuck_or_timeout_failure
-  image: curlimages/curl-base
-  script:
-    - 'curl -k ${COVERALLS_WEBHOOK_URL}?repo_token=${COVERALLS_TOKEN} -d "payload[build_num]=$CI_PIPELINE_ID&payload[status]=done"'
-    - 'curl -k "${COVERALLS_RERUN_BUILD_URL}?repo_token=${COVERALLS_TOKEN}&build_num=${CI_PIPELINE_ID}"'
+    - curl -Os https://uploader.codecov.io/latest/linux/codecov
+    - chmod +x codecov
+    - ./codecov --token ${CODECOV_TOKEN} --file coverage.txt --flag unittests --nonZero
+      --slug mendersoftware/${CI_PROJECT_NAME}
+      --pr $(echo "${CI_COMMIT_BRANCH}" | sed 's/^pr_//')
+      --service github

--- a/.gitlab-ci-check-golang-unittests.yml
+++ b/.gitlab-ci-check-golang-unittests.yml
@@ -18,7 +18,7 @@
 #   image: golang:1.11.4
 #
 # Requires the following variables set in the project CI/CD settings:
-#   COVERALLS_TOKEN: Token from coveralls.io for this repository
+#   CODECOV_TOKEN: Token from codecov.io for this repository
 #
 # By default, it installs MongoDB version 4.4 for Debian buster. You can
 # specify the Debian release name for the upstream APT repository and
@@ -98,51 +98,22 @@ test:unit:
 
 publish:unittests:
   tags:
-    - mender-qa-worker-generic-light
+    - k8s-small
   stage: publish
-  except:
-    - /^saas-[a-zA-Z0-9.]+$/
-  image: golang:1.23.4-alpine3.21
-  allow_failure: true # QA-925 - Coveralls servers are unreliable.
+  rules:
+    - if: '$CI_COMMIT_TAG =~ /^saas-[a-zA-Z0-9.]+$/'
+      when: never
+    - when: on_success
+  image: curlimages/curl-base
+  allow_failure: true
   dependencies:
     - test:unit
-  before_script:
-    - !reference [.qa-common-network-go-retry, before_script]
-    # Install dependencies
-    - apk add --no-cache git
-    - go install github.com/mattn/goveralls@latest
-    # Prepare GOPATH
-    - mkdir -p /go/src/github.com/mendersoftware
-    - cp -r ${CI_PROJECT_DIR} /go/src/github.com/mendersoftware/${CI_PROJECT_NAME}
-    - cd /go/src/github.com/mendersoftware/${CI_PROJECT_NAME}
-    # Coveralls env variables:
-    #  According to https://docs.coveralls.io/ci-services
-    #  we should set CI_NAME, CI_BUILD_NUMBER, etc. But according
-    #  to goveralls source code (https://github.com/mattn/goveralls)
-    #  many of these are not supported. Set CI_BRANCH,
-    #  and pass few others as command line arguments.
-    #  See also https://docs.coveralls.io/api-introduction
-    - export CI_BRANCH=${CI_COMMIT_BRANCH}
   script:
     - tar -xvf unit-coverage.tar
-    - goveralls
-      -repotoken ${COVERALLS_TOKEN}
-      -service gitlab-ci
-      -jobid $CI_PIPELINE_ID
-      -covermode set
-      -flagname unittests
-      -parallel
-      -coverprofile $(find tests/unit-coverage -name 'coverage.txt' | tr '\n' ',' | sed 's/,$//')
-
-coveralls:finish-build:
-  tags:
-    - mender-qa-worker-generic-light
-  stage: .post
-  # See https://docs.coveralls.io/api-parallel-build-webhook
-  variables:
-    COVERALLS_WEBHOOK_URL: "https://coveralls.io/webhook"
-    COVERALLS_RERUN_BUILD_URL: "https://coveralls.io/rerun_build"
-  image: curlimages/curl-base
-  script:
-    - 'curl -k ${COVERALLS_WEBHOOK_URL}?repo_token=${COVERALLS_TOKEN} -d "payload[build_num]=$CI_PIPELINE_ID&payload[status]=done"'
-    - 'curl -k "${COVERALLS_RERUN_BUILD_URL}?repo_token=${COVERALLS_TOKEN}&build_num=${CI_PIPELINE_ID}"'
+    - curl -Os https://uploader.codecov.io/latest/linux/codecov
+    - chmod +x codecov
+    - ./codecov --token ${CODECOV_TOKEN} --flag unittests --nonZero
+      --file $(find tests/unit-coverage -name 'coverage.txt' | tr '\n' ',' | sed 's/,$//')
+      --slug mendersoftware/${CI_PROJECT_NAME}
+      --pr $(echo "${CI_COMMIT_BRANCH}" | sed 's/^pr_//')
+      --service github

--- a/.gitlab-ci-github-status-updates.yml
+++ b/.gitlab-ci-github-status-updates.yml
@@ -14,18 +14,14 @@ stages:
 .github_status_template:
   tags:
     - k8s-small
-  # Keep overhead low by using a small image with curl and git preinstalled.
-  image: registry.gitlab.com/northern.tech/mender/mender-test-containers:base-alpine-master
+  # Keep overhead low by using a small image with curl preinstalled.
+  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/curlimages/curl-base
   retry:
     max: 2
     when:
       - runner_system_failure
       - stuck_or_timeout_failure
   before_script:
-    - |
-      _pr_sha=$(git rev-parse HEAD^2 2>/dev/null || true)
-      _sha="${_pr_sha:-${CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_SHA:-$CI_COMMIT_SHA}}"
-      GITHUB_STATUS_API_URL="https://api.github.com/repos/mendersoftware/$CI_PROJECT_NAME/statuses/$_sha"
     - |
       send_status() {
         local status="$1"


### PR DESCRIPTION
Switch publish jobs from goveralls+Coveralls to the Codecov uploader binary. Drop the coveralls:finish-build webhook job. Update variable name from COVERALLS_TOKEN to CODECOV_TOKEN.

Ticket: QA-1574