### PR TITLE
fix(coverage): unset GITLAB_CI before Codecov upload

### DIFF
--- a/.gitlab-ci-check-docker-acceptance.yml
+++ b/.gitlab-ci-check-docker-acceptance.yml
@@ -142,6 +142,7 @@ publish:acceptance:
   script:
     - curl -Os https://uploader.codecov.io/latest/linux/codecov
     - chmod +x codecov
+    - unset GITLAB_CI
     - ./codecov --token ${CODECOV_TOKEN} --file ./tests/coverage-acceptance.txt --flag acceptance --nonZero
       --slug mendersoftware/${CI_PROJECT_NAME}
       --pr $(echo "${CI_COMMIT_BRANCH}" | sed 's/^pr_//')

--- a/.gitlab-ci-check-golang-unittests-v2.yml
+++ b/.gitlab-ci-check-golang-unittests-v2.yml
@@ -81,6 +81,7 @@ publish:unittests:
   script:
     - curl -Os https://uploader.codecov.io/latest/linux/codecov
     - chmod +x codecov
+    - unset GITLAB_CI
     - ./codecov --token ${CODECOV_TOKEN} --file coverage.txt --flag unittests --nonZero
       --slug mendersoftware/${CI_PROJECT_NAME}
       --pr $(echo "${CI_COMMIT_BRANCH}" | sed 's/^pr_//')

--- a/.gitlab-ci-check-golang-unittests.yml
+++ b/.gitlab-ci-check-golang-unittests.yml
@@ -112,6 +112,7 @@ publish:unittests:
     - tar -xvf unit-coverage.tar
     - curl -Os https://uploader.codecov.io/latest/linux/codecov
     - chmod +x codecov
+    - unset GITLAB_CI
     - ./codecov --token ${CODECOV_TOKEN} --flag unittests --nonZero
       --file $(find tests/unit-coverage -name 'coverage.txt' | tr '\n' ',' | sed 's/,$//')
       --slug mendersoftware/${CI_PROJECT_NAME}


### PR DESCRIPTION
codecov uploader auto-detects GitLab CI and forces \`service=gitlab\`, ignoring the \`--service github\` flag this causes uploads to be associated with GitLab MRs instead of GitHub PRs, so the Codecov app never posts coverage comments

Ticket: QA-1574