### PR TITLE
fix(coverage): pass --sha explicitly to Codecov uploader

### DIFF
--- a/.gitlab-ci-check-docker-acceptance.yml
+++ b/.gitlab-ci-check-docker-acceptance.yml
@@ -141,6 +141,8 @@ publish:acceptance:
   allow_failure: true
   script:
     - curl -Os https://cli.codecov.io/latest/alpine/codecov
+    - curl -Os https://cli.codecov.io/latest/alpine/codecov.SHA256SUM
+    - sha256sum -c codecov.SHA256SUM
     - chmod +x codecov
     - ./codecov upload-process
       --fail-on-error

--- a/.gitlab-ci-check-docker-acceptance.yml
+++ b/.gitlab-ci-check-docker-acceptance.yml
@@ -140,10 +140,13 @@ publish:acceptance:
   image: curlimages/curl-base
   allow_failure: true
   script:
-    - curl -Os https://uploader.codecov.io/latest/linux/codecov
+    - curl -Os https://cli.codecov.io/latest/alpine/codecov
     - chmod +x codecov
-    - unset GITLAB_CI
-    - ./codecov --token ${CODECOV_TOKEN} --file ./tests/coverage-acceptance.txt --flag acceptance --nonZero
+    - ./codecov upload-process
+      --fail-on-error
+      --git-service github
       --slug mendersoftware/${CI_PROJECT_NAME}
+      --sha ${CI_COMMIT_SHA}
       --pr $(echo "${CI_COMMIT_BRANCH}" | sed 's/^pr_//')
-      --service github
+      --file ./tests/coverage-acceptance.txt
+      --flag acceptance

--- a/.gitlab-ci-check-golang-unittests-v2.yml
+++ b/.gitlab-ci-check-golang-unittests-v2.yml
@@ -79,10 +79,13 @@ publish:unittests:
   dependencies:
     - test:unit
   script:
-    - curl -Os https://uploader.codecov.io/latest/linux/codecov
+    - curl -Os https://cli.codecov.io/latest/alpine/codecov
     - chmod +x codecov
-    - unset GITLAB_CI
-    - ./codecov --token ${CODECOV_TOKEN} --file coverage.txt --flag unittests --nonZero
+    - ./codecov upload-process
+      --fail-on-error
+      --git-service github
       --slug mendersoftware/${CI_PROJECT_NAME}
+      --sha ${CI_COMMIT_SHA}
       --pr $(echo "${CI_COMMIT_BRANCH}" | sed 's/^pr_//')
-      --service github
+      --file coverage.txt
+      --flag unittests

--- a/.gitlab-ci-check-golang-unittests-v2.yml
+++ b/.gitlab-ci-check-golang-unittests-v2.yml
@@ -80,6 +80,8 @@ publish:unittests:
     - test:unit
   script:
     - curl -Os https://cli.codecov.io/latest/alpine/codecov
+    - curl -Os https://cli.codecov.io/latest/alpine/codecov.SHA256SUM
+    - sha256sum -c codecov.SHA256SUM
     - chmod +x codecov
     - ./codecov upload-process
       --fail-on-error

--- a/.gitlab-ci-check-golang-unittests.yml
+++ b/.gitlab-ci-check-golang-unittests.yml
@@ -111,6 +111,8 @@ publish:unittests:
   script:
     - tar -xvf unit-coverage.tar
     - curl -Os https://cli.codecov.io/latest/alpine/codecov
+    - curl -Os https://cli.codecov.io/latest/alpine/codecov.SHA256SUM
+    - sha256sum -c codecov.SHA256SUM
     - chmod +x codecov
     - ./codecov upload-process
       --fail-on-error

--- a/.gitlab-ci-check-golang-unittests.yml
+++ b/.gitlab-ci-check-golang-unittests.yml
@@ -110,11 +110,13 @@ publish:unittests:
     - test:unit
   script:
     - tar -xvf unit-coverage.tar
-    - curl -Os https://uploader.codecov.io/latest/linux/codecov
+    - curl -Os https://cli.codecov.io/latest/alpine/codecov
     - chmod +x codecov
-    - unset GITLAB_CI
-    - ./codecov --token ${CODECOV_TOKEN} --flag unittests --nonZero
-      --file $(find tests/unit-coverage -name 'coverage.txt' | tr '\n' ',' | sed 's/,$//')
+    - ./codecov upload-process
+      --fail-on-error
+      --git-service github
       --slug mendersoftware/${CI_PROJECT_NAME}
+      --sha ${CI_COMMIT_SHA}
       --pr $(echo "${CI_COMMIT_BRANCH}" | sed 's/^pr_//')
-      --service github
+      --file $(find tests/unit-coverage -name 'coverage.txt' | tr '\n' ',' | sed 's/,$//')
+      --flag unittests


### PR DESCRIPTION
## Summary

Follow-up to #478.

After unsetting `GITLAB_CI` to prevent service auto-detection, the Codecov uploader can no longer infer the commit SHA from GitLab env vars, causing uploads to fail with `Unable to detect SHA and slug`.

Fix: pass `--sha ${CI_COMMIT_SHA}` explicitly so the uploader has everything it needs without relying on GitLab CI auto-detection.

Ticket: QA-1574