### PR TITLE
chore: Bring back coverage templates to original state

### DIFF
--- a/.gitlab-ci-check-docker-acceptance.yml
+++ b/.gitlab-ci-check-docker-acceptance.yml
@@ -20,7 +20,7 @@
 #     file: '.gitlab-ci-check-docker-acceptance.yml'
 #
 # Requires the following variables set in the project CI/CD settings:
-#   CODECOV_TOKEN: Token from codecov.io for this repository
+#   COVERALLS_TOKEN: Token from coveralls.io for this repository
 #
 # If the tests require access to Mender Registry hosted images, it
 # will require also the following vabiables:
@@ -137,13 +137,43 @@ publish:acceptance:
     - if: '$CI_COMMIT_TAG =~ /^saas-[a-zA-Z0-9.]+$/'
       when: never
     - when: on_success
-  image: curlimages/curl-base
+  image: golang:1.20-alpine3.17
   allow_failure: true
+  before_script:
+    # Install dependencies
+    - apk add --no-cache git
+    - go install github.com/mattn/goveralls@latest
+    # Prepare GOPATH
+    - mkdir -p /go/src/github.com/mendersoftware
+    - cp -r ${CI_PROJECT_DIR} /go/src/github.com/mendersoftware/${CI_PROJECT_NAME}
+    - cd /go/src/github.com/mendersoftware/${CI_PROJECT_NAME}
+    # Coveralls env variables:
+    #  According to https://docs.coveralls.io/ci-services
+    #  we should set CI_NAME, CI_BUILD_NUMBER, etc. But according
+    #  to goveralls source code (https://github.com/mattn/goveralls)
+    #  many of these are not supported. Set CI_BRANCH
+    #  and pass few others as command line arguments.
+    #  See also https://docs.coveralls.io/api-introduction
+    - export CI_BRANCH=${CI_COMMIT_BRANCH}
   script:
-    - curl -Os https://uploader.codecov.io/latest/linux/codecov
-    - chmod +x codecov
-    - unset GITLAB_CI
-    - ./codecov --token ${CODECOV_TOKEN} --file ./tests/coverage-acceptance.txt --flag acceptance --nonZero
-      --slug mendersoftware/${CI_PROJECT_NAME}
-      --pr $(echo "${CI_COMMIT_BRANCH}" | sed 's/^pr_//')
-      --service github
+    - goveralls
+      -repotoken ${COVERALLS_TOKEN}
+      -service gitlab-ci
+      -jobid $CI_PIPELINE_ID
+      -covermode set
+      -flagname acceptance
+      -parallel
+      -coverprofile ./tests/coverage-acceptance.txt
+
+coveralls:finish-build:
+  tags:
+    - mender-qa-worker-generic-light
+  stage: .post
+  # See https://docs.coveralls.io/api-parallel-build-webhook
+  variables:
+    COVERALLS_WEBHOOK_URL: "https://coveralls.io/webhook"
+    COVERALLS_RERUN_BUILD_URL: "https://coveralls.io/rerun_build"
+  image: curlimages/curl-base
+  script:
+    - 'curl -k ${COVERALLS_WEBHOOK_URL}?repo_token=${COVERALLS_TOKEN} -d "payload[build_num]=$CI_PIPELINE_ID&payload[status]=done"'
+    - 'curl -k "${COVERALLS_RERUN_BUILD_URL}?repo_token=${COVERALLS_TOKEN}&build_num=${CI_PIPELINE_ID}"'

--- a/.gitlab-ci-check-golang-unittests-v2.yml
+++ b/.gitlab-ci-check-golang-unittests-v2.yml
@@ -10,7 +10,7 @@
 #     file: '.gitlab-ci-check-golang-unittests-v2.yml'
 #
 # Requires the following variables set in the project CI/CD settings:
-#   CODECOV_TOKEN: Token from codecov.io for this repository
+#   COVERALLS_TOKEN: Token from coveralls.io for this repository
 #
 stages:
   - test
@@ -33,8 +33,10 @@ test:unit:
     when:
       - runner_system_failure
       - stuck_or_timeout_failure
-  except:
-    - /^saas-[a-zA-Z0-9.]+$/
+  rules:
+    - if: '$CI_COMMIT_TAG =~ /^saas-[a-zA-Z0-9.]+$/'
+      when: never
+    - when: on_success
   image: golang:${GO_VERSION}
   services:
     - "mongo:${MONGO_VERSION}"
@@ -75,14 +77,43 @@ publish:unittests:
     - if: '$CI_COMMIT_TAG =~ /^saas-[a-zA-Z0-9.]+$/'
       when: never
     - when: on_success
-  image: curlimages/curl-base
+  image: golang:1.23.4
   dependencies:
     - test:unit
+  before_script:
+    - !reference [.qa-common-network-go-retry, before_script]
+    # Install dependencies
+    - go install github.com/mattn/goveralls@v0.0.12
+    # Coveralls env variables:
+    #  According to https://docs.coveralls.io/ci-services
+    #  we should set CI_NAME, CI_BUILD_NUMBER, etc. But according
+    #  to goveralls source code (https://github.com/mattn/goveralls)
+    #  many of these are not supported. Set CI_BRANCH,
+    #  and pass few others as command line arguments.
+    #  See also https://docs.coveralls.io/api-introduction
+    - export CI_BRANCH=${CI_COMMIT_BRANCH}
   script:
-    - curl -Os https://uploader.codecov.io/latest/linux/codecov
-    - chmod +x codecov
-    - unset GITLAB_CI
-    - ./codecov --token ${CODECOV_TOKEN} --file coverage.txt --flag unittests --nonZero
-      --slug mendersoftware/${CI_PROJECT_NAME}
-      --pr $(echo "${CI_COMMIT_BRANCH}" | sed 's/^pr_//')
-      --service github
+    - goveralls
+      -coverprofile coverage.txt
+      -service gitlab-ci
+      -jobid $CI_PIPELINE_ID
+      -flagname unittests
+      -parallel
+
+coveralls:finish-build:
+  tags:
+    - mender-qa-worker-generic-light
+  stage: .post
+  # See https://docs.coveralls.io/api-parallel-build-webhook
+  variables:
+    COVERALLS_WEBHOOK_URL: "https://coveralls.io/webhook"
+    COVERALLS_RERUN_BUILD_URL: "https://coveralls.io/rerun_build"
+  retry:
+    max: 2
+    when:
+      - runner_system_failure
+      - stuck_or_timeout_failure
+  image: curlimages/curl-base
+  script:
+    - 'curl -k ${COVERALLS_WEBHOOK_URL}?repo_token=${COVERALLS_TOKEN} -d "payload[build_num]=$CI_PIPELINE_ID&payload[status]=done"'
+    - 'curl -k "${COVERALLS_RERUN_BUILD_URL}?repo_token=${COVERALLS_TOKEN}&build_num=${CI_PIPELINE_ID}"'

--- a/.gitlab-ci-check-golang-unittests.yml
+++ b/.gitlab-ci-check-golang-unittests.yml
@@ -18,7 +18,7 @@
 #   image: golang:1.11.4
 #
 # Requires the following variables set in the project CI/CD settings:
-#   CODECOV_TOKEN: Token from codecov.io for this repository
+#   COVERALLS_TOKEN: Token from coveralls.io for this repository
 #
 # By default, it installs MongoDB version 4.4 for Debian buster. You can
 # specify the Debian release name for the upstream APT repository and
@@ -39,8 +39,10 @@ test:unit:
     - mender-qa-worker-generic-light
   stage: test
   needs: []
-  except:
-    - /^saas-[a-zA-Z0-9.]+$/
+  rules:
+    - if: '$CI_COMMIT_TAG =~ /^saas-[a-zA-Z0-9.]+$/'
+      when: never
+    - when: on_success
   image: golang:1.23.4
   services:
     - mongo:8.0
@@ -104,17 +106,47 @@ publish:unittests:
     - if: '$CI_COMMIT_TAG =~ /^saas-[a-zA-Z0-9.]+$/'
       when: never
     - when: on_success
-  image: curlimages/curl-base
-  allow_failure: true
+  image: golang:1.23.4-alpine3.21
+  allow_failure: true # QA-925 - Coveralls servers are unreliable.
   dependencies:
     - test:unit
+  before_script:
+    - !reference [.qa-common-network-go-retry, before_script]
+    # Install dependencies
+    - apk add --no-cache git
+    - go install github.com/mattn/goveralls@latest
+    # Prepare GOPATH
+    - mkdir -p /go/src/github.com/mendersoftware
+    - cp -r ${CI_PROJECT_DIR} /go/src/github.com/mendersoftware/${CI_PROJECT_NAME}
+    - cd /go/src/github.com/mendersoftware/${CI_PROJECT_NAME}
+    # Coveralls env variables:
+    #  According to https://docs.coveralls.io/ci-services
+    #  we should set CI_NAME, CI_BUILD_NUMBER, etc. But according
+    #  to goveralls source code (https://github.com/mattn/goveralls)
+    #  many of these are not supported. Set CI_BRANCH,
+    #  and pass few others as command line arguments.
+    #  See also https://docs.coveralls.io/api-introduction
+    - export CI_BRANCH=${CI_COMMIT_BRANCH}
   script:
     - tar -xvf unit-coverage.tar
-    - curl -Os https://uploader.codecov.io/latest/linux/codecov
-    - chmod +x codecov
-    - unset GITLAB_CI
-    - ./codecov --token ${CODECOV_TOKEN} --flag unittests --nonZero
-      --file $(find tests/unit-coverage -name 'coverage.txt' | tr '\n' ',' | sed 's/,$//')
-      --slug mendersoftware/${CI_PROJECT_NAME}
-      --pr $(echo "${CI_COMMIT_BRANCH}" | sed 's/^pr_//')
-      --service github
+    - goveralls
+      -repotoken ${COVERALLS_TOKEN}
+      -service gitlab-ci
+      -jobid $CI_PIPELINE_ID
+      -covermode set
+      -flagname unittests
+      -parallel
+      -coverprofile $(find tests/unit-coverage -name 'coverage.txt' | tr '\n' ',' | sed 's/,$//')
+
+coveralls:finish-build:
+  tags:
+    - mender-qa-worker-generic-light
+  stage: .post
+  # See https://docs.coveralls.io/api-parallel-build-webhook
+  variables:
+    COVERALLS_WEBHOOK_URL: "https://coveralls.io/webhook"
+    COVERALLS_RERUN_BUILD_URL: "https://coveralls.io/rerun_build"
+  image: curlimages/curl-base
+  script:
+    - 'curl -k ${COVERALLS_WEBHOOK_URL}?repo_token=${COVERALLS_TOKEN} -d "payload[build_num]=$CI_PIPELINE_ID&payload[status]=done"'
+    - 'curl -k "${COVERALLS_RERUN_BUILD_URL}?repo_token=${COVERALLS_TOKEN}&build_num=${CI_PIPELINE_ID}"'


### PR DESCRIPTION
Bring back `.gitlab-ci-check-golang-unittests.yml`, `.gitlab-ci-check-golang-unittests-v2.yml`, and `.gitlab-ci-check-docker-acceptance.yml` to their state before QA-1574 change are kept as-is per team decision.

Ticket: QA-1574