### PR TITLE
ci: switch test container images to per-image registry paths

### DIFF
--- a/.gitlab-ci-check-apidocs.yml
+++ b/.gitlab-ci-check-apidocs.yml
@@ -92,7 +92,7 @@ trigger:apidocs:rebuild-mender-api-docs:
       - docs/*
       if: '$CI_COMMIT_BRANCH =~ /^(master|staging|[0-9]+\.[0-9]+\.x)$/'
     - if: '$REBUILD_MENDER_API_DOCS == "true"'
-  image: registry.gitlab.com/northern.tech/mender/mender-test-containers:base-alpine-master
+  image: registry.gitlab.com/northern.tech/mender/mender-test-containers/base-alpine:master
   before_script:
     - !reference [.qa-common-network-git-clone-retry, before_script]
     - apk add --no-cache python3 py3-pip

--- a/.gitlab-ci-check-commits-signoffs.yml
+++ b/.gitlab-ci-check-commits-signoffs.yml
@@ -18,7 +18,7 @@ test:check-commits:
       - stuck_or_timeout_failure
   except:
     - /^(master|hosted|staging|production|saas-v[0-9.]+|[0-9]+\.[0-9]+\.x)$/
-  image: registry.gitlab.com/northern.tech/mender/mender-test-containers:base-alpine-master
+  image: registry.gitlab.com/northern.tech/mender/mender-test-containers/base-alpine:master
   variables:
     GIT_STRATEGY: clone # clone entire repo instead of reusing workspace
     GIT_DEPTH: 0 # avoid shallow clone, this test requires full git history

--- a/.gitlab-ci-check-commits.yml
+++ b/.gitlab-ci-check-commits.yml
@@ -18,7 +18,7 @@ test:check-commits:
       - stuck_or_timeout_failure
   except:
     - /^(master|hosted|staging|production|saas-v[0-9.]+|[0-9]+\.[0-9]+\.x|[0-9]+\.[0-9]+\.[0-9]+)$/
-  image: registry.gitlab.com/northern.tech/mender/mender-test-containers:base-alpine-master
+  image: registry.gitlab.com/northern.tech/mender/mender-test-containers/base-alpine:master
   variables:
     GIT_STRATEGY: clone # clone entire repo instead of reusing workspace
     GIT_DEPTH: 0 # avoid shallow clone, this test requires full git history

--- a/.gitlab-ci-check-docker-build.yml
+++ b/.gitlab-ci-check-docker-build.yml
@@ -180,7 +180,7 @@ build:docker-multiplatform:
     - if: '$CI_COMMIT_TAG =~ /^saas-[a-zA-Z0-9.]+$/'
       when: never
     - when: on_success
-  image: "registry.gitlab.com/northern.tech/mender/mender-test-containers:docker-multiplatform-buildx-v1-master"
+  image: "registry.gitlab.com/northern.tech/mender/mender-test-containers/docker-multiplatform-buildx:master"
   services:
     - name: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:28-dind
       alias: docker
@@ -248,7 +248,7 @@ publish:image-multiplatform:
     - if: $MULTIPLATFORM_BUILD != "true"
       when: never
     - if: '$CI_COMMIT_BRANCH =~ /^(main|master|staging|production|feature-.+|v?\d+\.\d+\.x)$/'
-  image: "registry.gitlab.com/northern.tech/mender/mender-test-containers:docker-multiplatform-buildx-v1-master"
+  image: "registry.gitlab.com/northern.tech/mender/mender-test-containers/docker-multiplatform-buildx:master"
   services:
     - name: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:28-dind
       alias: docker
@@ -322,7 +322,7 @@ publish:image-multiplatform:mender:
     - if: $MULTIPLATFORM_BUILD != "true"
       when: never
     - if: '$CI_COMMIT_BRANCH =~ /^(master|[0-9]+\.[0-9]+\.x)$/'
-  image: "registry.gitlab.com/northern.tech/mender/mender-test-containers:docker-multiplatform-buildx-v1-master"
+  image: "registry.gitlab.com/northern.tech/mender/mender-test-containers/docker-multiplatform-buildx:master"
   services:
     - name: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:28-dind
       alias: docker
@@ -387,7 +387,7 @@ publish:image-multiplatform:saas:
     - if: $MULTIPLATFORM_BUILD != "true"
       when: never
     - if: '$CI_COMMIT_TAG =~ /^saas-[a-zA-Z0-9.]+$/'
-  image: "registry.gitlab.com/northern.tech/mender/mender-test-containers:docker-multiplatform-buildx-v1-master"
+  image: "registry.gitlab.com/northern.tech/mender/mender-test-containers/docker-multiplatform-buildx:master"
   services:
     - name: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:28-dind
       alias: docker

--- a/.gitlab-ci-check-docker-deploy.yml
+++ b/.gitlab-ci-check-docker-deploy.yml
@@ -59,7 +59,7 @@ sync:image:
   dependencies:
     - publish:image
   stage: sync
-  image: registry.gitlab.com/northern.tech/mender/mender-test-containers:base-debian-master
+  image: registry.gitlab.com/northern.tech/mender/mender-test-containers/base-debian:master
   before_script:
     - !reference [.qa-common-network-apt-retry, before_script]
     - !reference [.qa-common-network-git-clone-retry, before_script]

--- a/.gitlab-ci-check-helm-version-bump.yml
+++ b/.gitlab-ci-check-helm-version-bump.yml
@@ -40,7 +40,7 @@ helm-version-bump:
     when:
       - runner_system_failure
       - stuck_or_timeout_failure
-  image: registry.gitlab.com/northern.tech/mender/mender-test-containers:aws-k8s-v1-master
+  image: registry.gitlab.com/northern.tech/mender/mender-test-containers/aws-k8s-toolbox:master
   before_script:
     - |
       echo "INFO - setting up git"

--- a/.gitlab-ci-check-license.yml
+++ b/.gitlab-ci-check-license.yml
@@ -54,7 +54,7 @@ test:check-license:
       - licenses.csv
       when: never
     - when: always
-  image: registry.gitlab.com/northern.tech/mender/mender-test-containers:base-alpine-master
+  image: registry.gitlab.com/northern.tech/mender/mender-test-containers/base-alpine:master
   variables:
     GIT_STRATEGY: clone # clone entire repo instead of reusing workspace
     GIT_DEPTH: 0 # avoid shallow clone, this test requires full git history
@@ -118,7 +118,7 @@ test:check-license-source:
     when:
       - runner_system_failure
       - stuck_or_timeout_failure
-  image: registry.gitlab.com/northern.tech/mender/mender-test-containers:base-alpine-master
+  image: registry.gitlab.com/northern.tech/mender/mender-test-containers/base-alpine:master
   variables:
     GIT_STRATEGY: clone # clone entire repo instead of reusing workspace
     GIT_DEPTH: 0 # avoid shallow clone, this test requires full git history

--- a/.gitlab-ci-check-python3-format.yml
+++ b/.gitlab-ci-check-python3-format.yml
@@ -54,7 +54,7 @@ stages:
 test:check-python3-formatting:
   tags:
     - k8s-small
-  image: registry.gitlab.com/northern.tech/mender/mender-test-containers:python-black-master
+  image: registry.gitlab.com/northern.tech/mender/mender-test-containers/python-black:master
   stage: test
   needs: []
   retry:

--- a/.gitlab-ci-check-shell-format.yml
+++ b/.gitlab-ci-check-shell-format.yml
@@ -35,7 +35,7 @@ test:check-shell-formatting:
     when:
       - runner_system_failure
       - stuck_or_timeout_failure
-  image: registry.gitlab.com/northern.tech/mender/mender-test-containers:base-alpine-master
+  image: registry.gitlab.com/northern.tech/mender/mender-test-containers/base-alpine:master
   before_script:
     - SHELL_SCRIPTS=$(find . -type f -name "*.sh")
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,7 +68,7 @@ test:unit:
 test:unit:commitlint:
   tags:
     - k8s-small
-  image: registry.gitlab.com/northern.tech/mender/mender-test-containers:base-alpine-master
+  image: registry.gitlab.com/northern.tech/mender/mender-test-containers/base-alpine:master
   stage: test
   before_script:
     - apk add --no-cache gawk

--- a/templates/commit-lint.yml
+++ b/templates/commit-lint.yml
@@ -84,7 +84,7 @@ lint:commit:signoffs:
   tags:
     - $[[ inputs.runner ]]
   needs: []
-  image: registry.gitlab.com/northern.tech/mender/mender-test-containers:base-alpine-master
+  image: registry.gitlab.com/northern.tech/mender/mender-test-containers/base-alpine:master
   retry:
     max: 2
     when:

--- a/templates/release-candidate.yml
+++ b/templates/release-candidate.yml
@@ -22,7 +22,7 @@ release:candidate:update-changelog:
     - $[[ inputs.runner ]]
   needs: []
   image:
-    name: "registry.gitlab.com/northern.tech/mender/mender-test-containers:release-please-v1-master"
+    name: "registry.gitlab.com/northern.tech/mender/mender-test-containers/release-please:master"
     entrypoint: [""]
   retry:
     max: 2
@@ -95,7 +95,7 @@ release:candidate:update-changelog:
 
 release:candidate:tag-and-release:
   stage: $[[ inputs.stage ]]
-  image: "registry.gitlab.com/northern.tech/mender/mender-test-containers:release-please-v1-master"
+  image: "registry.gitlab.com/northern.tech/mender/mender-test-containers/release-please:master"
   tags:
     - $[[ inputs.runner ]]
   needs:

--- a/templates/release-mender-docs.yml
+++ b/templates/release-mender-docs.yml
@@ -22,7 +22,7 @@ release:mender-docs:
     - $[[ inputs.runner ]]
   needs: []
   image:
-    name: "registry.gitlab.com/northern.tech/mender/mender-test-containers:release-please-v1-master"
+    name: "registry.gitlab.com/northern.tech/mender/mender-test-containers/release-please:master"
     entrypoint: [""]
   retry:
     max: 2

--- a/templates/release-oslicenses-golang.yml
+++ b/templates/release-oslicenses-golang.yml
@@ -73,7 +73,7 @@ release:golanglicenses:publish:
     # Only make available for stable and protected tags
     - if: '$CI_COMMIT_TAG =~ /^v?\d+\.\d+\.\d+$/ && $CI_COMMIT_REF_PROTECTED == "true"'
       allow_failure: true
-  image: "registry.gitlab.com/northern.tech/mender/mender-test-containers:release-please-v1-master"
+  image: "registry.gitlab.com/northern.tech/mender/mender-test-containers/release-please:master"
   needs:
     - job: release:golanglicenses:generate
       artifacts: true


### PR DESCRIPTION
Migrates all `mender-test-containers` image references in CI templates from the legacy flat-tag format to the new per-image sub-repository format:

- `mender-test-containers:base-alpine-master` → `mender-test-containers/base-alpine:master`
- `mender-test-containers:base-debian-master` → `mender-test-containers/base-debian:master`
- `mender-test-containers:aws-k8s-v1-master` → `mender-test-containers/aws-k8s-toolbox:master`
- `mender-test-containers:docker-multiplatform-buildx-v1-master` → `mender-test-containers/docker-multiplatform-buildx:master`
- `mender-test-containers:python-black-master` → `mender-test-containers/python-black:master`
- `mender-test-containers:release-please-v1-master` → `mender-test-containers/release-please:master`

Ticket: QA-1598, QA-1599, QA-1602, QA-1603, QA-1608, QA-1609