### PR TITLE
Bump to latest go 1.26 in go templates

### DIFF
--- a/.gitlab-ci-check-golang-unittests-v2.yml
+++ b/.gitlab-ci-check-golang-unittests-v2.yml
@@ -22,7 +22,7 @@ test:unit:
     GIT_STRATEGY: clone # clone entire repo instead of reusing workspace
     GIT_DEPTH: 0 # avoid shallow clone, this test requires full git history
     TEST_MONGO_URL: "mongodb://mongo"
-    GO_VERSION: "1.24"
+    GO_VERSION: "1.26"
 
   tags:
     - mender-qa-worker-generic-light

--- a/templates/release-oslicenses-golang.yml
+++ b/templates/release-oslicenses-golang.yml
@@ -4,7 +4,7 @@ spec:
       description: Remote license file to be used (e.g., "302.Release-information/03.Open-source-licenses/30.mender-artifact/docs.md")
     golang_version:
       description: Golang version image to be used
-      default: "1.24"
+      default: "1.26"
     golang_flags:
       description: Golang flags to be used
       default: ""


### PR DESCRIPTION
PRs like https://github.com/mendersoftware/mender-setup/pull/67 require newer golang versions (https://gitlab.com/Northern.tech/Mender/mender-setup/-/pipelines/2506546710)

We don't pin every golang repo to an old golang version, as only the components with recipes in meta-mender need to maintain backwards compatibility with the go version in Yocto. This means that some repos bump dependencies and therefore require newer go versions