### PR TITLE
fix: Mantra send results on unprotected

### DIFF
--- a/qa-common/send-results-to-mantra.yml
+++ b/qa-common/send-results-to-mantra.yml
@@ -7,45 +7,43 @@ variables:
 # This can also be directly used in files that include this component with '!reference [.mantra-push-results]'
 .mantra-push-results: &mantra-push-results
   - |
-    if [ "$CI_COMMIT_REF_PROTECTED" != "true" ]; then
-      echo "Mantra results will be submitted only from protected branches."
-      exit 0
-    fi
-    # First setup Mantra script
-    echo "Setting up Mantra test results uploader..."
-    curl --silent --show-error --location --fail \
-      ${MANTRA_SCRIPT_URL} \
-      --output /usr/local/bin/mantra_post_test_results
-    chmod +x /usr/local/bin/mantra_post_test_results
+    if [ "$CI_COMMIT_REF_PROTECTED" = "true" ]; then
+      # First setup Mantra script
+      echo "Setting up Mantra test results uploader..."
+      curl --silent --show-error --location --fail \
+        ${MANTRA_SCRIPT_URL} \
+        --output /usr/local/bin/mantra_post_test_results
+      chmod +x /usr/local/bin/mantra_post_test_results
 
-    # Mantra project name is a test ID recognized by Mantra
-    if [ -z $MANTRA_PROJECT_NAME ]; then
-      echo "Mantra project name not set"
-      exit 1
-    fi
-
-    # Scheduled builds in our case are nightly builds
-    if [ "$CI_PIPELINE_SOURCE" = "schedule" ]; then
-      MANTRA_BUILD_NAME="nightly-$(date +%Y-%m-%d)-${CI_PIPELINE_ID}"
-    else
-      MANTRA_BUILD_NAME="pullreq-$(date +%Y-%m-%d)-${CI_PIPELINE_ID}"
-    fi
-
-    echo "Uploading test results to Mantra (project=$MANTRA_PROJECT_NAME, build=$MANTRA_BUILD_NAME)"
-
-    # Find and upload all test results files
-    results_found=false
-    for results_file in $(find . -type f -name "results*.xml" 2>/dev/null); do
-      if [ -f "$results_file" ]; then
-        echo "Posting $results_file to Mantra"
-        /usr/local/bin/mantra_post_test_results --ensure \
-          "$MANTRA_PROJECT_NAME" \
-          "$MANTRA_BUILD_NAME" \
-          "$results_file" || echo "Failed to post $results_file (non-fatal)"
-        results_found=true
+      # Mantra project name is a test ID recognized by Mantra
+      if [ -z $MANTRA_PROJECT_NAME ]; then
+        echo "Mantra project name not set"
+        exit 1
       fi
-    done
 
-    if [ "$results_found" = false ]; then
-      echo "No test result files found to upload"
+      # Scheduled builds in our case are nightly builds
+      if [ "$CI_PIPELINE_SOURCE" = "schedule" ]; then
+        MANTRA_BUILD_NAME="nightly-$(date +%Y-%m-%d)-${CI_PIPELINE_ID}"
+      else
+        MANTRA_BUILD_NAME="pullreq-$(date +%Y-%m-%d)-${CI_PIPELINE_ID}"
+      fi
+
+      echo "Uploading test results to Mantra (project=$MANTRA_PROJECT_NAME, build=$MANTRA_BUILD_NAME)"
+
+      # Find and upload all test results files
+      results_found=false
+      for results_file in $(find . -type f -name "results*.xml" 2>/dev/null); do
+        if [ -f "$results_file" ]; then
+          echo "Posting $results_file to Mantra"
+          /usr/local/bin/mantra_post_test_results --ensure \
+            "$MANTRA_PROJECT_NAME" \
+            "$MANTRA_BUILD_NAME" \
+            "$results_file" || echo "Failed to post $results_file (non-fatal)"
+          results_found=true
+        fi
+      done
+
+      if [ "$results_found" = false ]; then
+        echo "No test result files found to upload"
+      fi
     fi


### PR DESCRIPTION
Previous send-results script caused status of job not to be posted on unprotected branches in ci/mender-qa due to exit 0 preventing the execution of the rest of the after_script.

Ticket: QA-1652