### PR TITLE
ci: allow golang-unittests-v2 to use a prebuilt test image

### DIFF
--- a/.gitlab-ci-check-golang-unittests-v2.yml
+++ b/.gitlab-ci-check-golang-unittests-v2.yml
@@ -23,6 +23,8 @@ test:unit:
     GIT_DEPTH: 0 # avoid shallow clone, this test requires full git history
     TEST_MONGO_URL: "mongodb://mongo"
     GO_VERSION: "1.26"
+    # Override to a prebuilt image (e.g. base-mender-go) to skip runtime installs.
+    GO_TEST_IMAGE: "golang:${GO_VERSION}"
 
   tags:
     - k8s
@@ -35,7 +37,7 @@ test:unit:
       - stuck_or_timeout_failure
   except:
     - /^saas-[a-zA-Z0-9.]+$/
-  image: golang:${GO_VERSION}
+  image: ${GO_TEST_IMAGE}
   services:
     - "mongo:${MONGO_VERSION}"
   before_script:
@@ -46,12 +48,10 @@ test:unit:
     -   apt-get -qq update && apt-get install -yq $(cat deb-requirements.txt)
     - fi
   script:
-    # Install JUnit test reporting formatter
-    - go install github.com/jstemmer/go-junit-report@v1.0.0
-    # Run tests
-    - go test ./... -v -covermode=atomic -coverprofile=coverage.txt 2>&1 |
-      tee /dev/stderr |
-      go-junit-report > test-results.xml || exit $?
+    # Install the test runner unless it is baked into the image (e.g. base-mender-go)
+    - if ! command -v gotestsum >/dev/null 2>&1; then go install gotest.tools/gotestsum@v1.13.0; fi
+    # Run tests -> JUnit report + coverage profile (gotestsum sets the exit code)
+    - gotestsum --junitfile test-results.xml --format testname -- ./... -covermode=atomic -coverprofile=coverage.txt
 
   artifacts:
     expire_in: 2w


### PR DESCRIPTION
## What
Lets the existing `golang-unittests-v2` template run on a prebuilt image instead of adding a
separate v3 template (avoids template sprawl):
- new `GO_TEST_IMAGE` var, default `golang:${GO_VERSION}` (behaviour unchanged for everyone)
- `go install go-junit-report` now runs only `if ! command -v go-junit-report` (skipped when baked)
- the `deb-requirements.txt` install was already conditional on the file existing

A repo opts in by setting `GO_TEST_IMAGE: …/base-mender-go:master` and deleting its
`deb-requirements.txt` — no runtime apt/go install, no new template.

## Why
QA-1637 (epic QA-1636, pipeline robustness). Replaces the earlier v3-template approach (closed #494).

## Compatibility
Zero blast radius: current v2 consumers are unaffected (default keeps `golang:${GO_VERSION}` and
still installs the reporter). Opt-in is per-repo and reversible (remove one variable).

## Rollout
Requires the `base-mender-go` image (mender-test-containers PR #725) published first. First consumer:
mender-setup PR #69.

Ticket: QA-1637