### PR TITLE
ci: Deprecate non multiplatform jobs in template

### DIFF
--- a/.gitlab-ci-check-docker-build.yml
+++ b/.gitlab-ci-check-docker-build.yml
@@ -148,15 +148,8 @@ build:docker:
   before_script:
     - *export_docker_vars
   script:
-    - *requires-docker-common
-    - echo "building ${CI_PROJECT_NAME} for ${DOCKER_BUILD_SERVICE_IMAGE}"
-    - docker build
-        --tag $DOCKER_BUILD_SERVICE_IMAGE
-        --file ${DOCKER_DIR:-.}/${DOCKERFILE:-Dockerfile}
-        --build-arg GIT_COMMIT_TAG="${DOCKER_PUBLISH_COMMIT_TAG}"
-        ${DOCKER_BUILD_ARGS}
-        ${DOCKER_DIR:-.}
-    - docker save $DOCKER_BUILD_SERVICE_IMAGE > ${IMAGE_ARTIFACT_FILENAME:-${CI_PROJECT_DIR}/image.tar}
+    - echo "ERROR: Deprecated Job!"
+    - exit 1
   artifacts:
     expire_in: 2w
     paths:
@@ -183,6 +176,7 @@ build:docker-multiplatform:
   before_script:
     - *dind-login
     - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
+    - *export_docker_vars
   script:
     - echo "building ${CI_PROJECT_NAME} with tags ${GITLAB_REGISTRY_TAG} and ${CI_REGISTRY_IMAGE}:${CI_COMMIT_REF_NAME}"
     - docker context create builder
@@ -213,12 +207,8 @@ publish:image:
     - *export_docker_vars
     - *docker_login_registries
   script:
-    - docker load -i ${IMAGE_ARTIFACT_FILENAME:-${CI_PROJECT_DIR}/image.tar}
-    - docker tag $DOCKER_BUILD_SERVICE_IMAGE $DOCKER_REPOSITORY:$DOCKER_PUBLISH_TAG
-    - docker tag $DOCKER_BUILD_SERVICE_IMAGE $DOCKER_REPOSITORY:$DOCKER_PUBLISH_COMMIT_TAG
-    - docker push $DOCKER_REPOSITORY:$DOCKER_PUBLISH_TAG
-    - docker push $DOCKER_REPOSITORY:$DOCKER_PUBLISH_COMMIT_TAG
-    - echo "PUBLISH_IMAGE_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' $DOCKER_REPOSITORY:$DOCKER_PUBLISH_TAG)" >> publish.env
+    - echo "ERROR: Deprecated Job!"
+    - exit 1
   artifacts:
     reports:
       dotenv: publish.env
@@ -279,16 +269,8 @@ publish:image:mender:
   allow_failure:
     exit_codes: 137
   script:
-    # Load image
-    - docker load -i ${IMAGE_ARTIFACT_FILENAME:-${CI_PROJECT_DIR}/image.tar}
-    # Publish the image for all releases
-    - for version in $integration_versions; do
-    -   docker tag $DOCKER_BUILD_SERVICE_IMAGE $DOCKER_REPOSITORY:mender-${version}
-    -   docker tag $DOCKER_BUILD_SERVICE_IMAGE $DOCKER_REPOSITORY:mender-${version}_${CI_COMMIT_SHA}
-    -   docker push $DOCKER_REPOSITORY:mender-${version}
-    -   docker push $DOCKER_REPOSITORY:mender-${version}_${CI_COMMIT_SHA}
-    - done
-    - echo "PUBLISH_IMAGE_MENDER_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' $DOCKER_REPOSITORY:mender-${version})" >> publish.env
+    - echo "ERROR: Deprecated Job!"
+    - exit 1
   artifacts:
     reports:
       dotenv: publish.env
@@ -352,9 +334,8 @@ publish:image:saas:
     - SERVICE_IMAGE=${DOCKER_REPOSITORY}:${DOCKER_PUBLISH_TAG}
     - *docker_login_registries
   script:
-    - docker pull $DOCKER_REPOSITORY:$SOURCE_TAG
-    - docker tag $DOCKER_REPOSITORY:$SOURCE_TAG $SERVICE_IMAGE
-    - docker push $SERVICE_IMAGE
+    - echo "ERROR: Deprecated Job!"
+    - exit 1
 
 publish:image-multiplatform:saas:
   stage: publish


### PR DESCRIPTION
Legacy jobs in template need to be deprecated. At the same time the repos still using these jobs need to be updated.

Ticket: QA-1487