### PR TITLE
docs(release): add changelog curation stage to the 3C release process

### DIFF
--- a/templates/README.3CRelease.md
+++ b/templates/README.3CRelease.md
@@ -1,6 +1,6 @@
 # Click Click Click Release Process
 
-<!-- Last updated: 2025-09-23 -->
+<!-- Last updated: 2026-07-02 -->
 
 ## Introduction
 
@@ -29,6 +29,17 @@ Before initiating a release, verify that all prerequisites are met:
 ### 🧨 Second Click: Run the Show
 Execute the release preparation and validation:
 - **Review and merge Release Candidate** Review generated changelog PR `https://github.com/mendersoftware/<repository>/pulls?q=is%3Apr+is%3Aopen+label%3A%22autorelease%3A+pending%22`
+- **Curate the changelog** - Edit the generated changelog in the Release Candidate PR before merging (see
+  [commits-and-release-notes](https://github.com/mendersoftware/mender-qa/blob/master/Documentation/commits-and-release-notes.md)
+  section 4; budget 15-30 minutes):
+  - **Highlights** - Hand-write a `## Highlights` section at the top (release engineer + PO): one short
+    paragraph per notable feature, with a documentation link. This is also the source material for the
+    blog post. Skip if the release has nothing to announce.
+  - **Security** - Add manual entries for coordinated disclosures or CVEs assigned after the commits
+    landed. CVE-flagged dependency bumps are included automatically.
+  - **Improvements** - Optionally promote behavior-affecting `refactor` entries into Improvements, and
+    move any misclassified entry to the right section.
+  - **All tickets resolved** - Verify the appendix table is present and its ticket links resolve.
 - **Tag and publish the Release** - Trigger the manual job from `https://gitlab.com/Northern.tech/Mender/<repository>/-/jobs?statuses=MANUAL`
 
 ### 📦 Third Click: Deliver It


### PR DESCRIPTION
Documents the manual curation pass on the release-candidate PR, per the new changelog policy ([commits-and-release-notes §4](https://github.com/mendersoftware/mender-qa/blob/master/Documentation/commits-and-release-notes.md)):

- Hand-written **Highlights** section (release engineer + PO, 15–30 min budget; source material for the blog post)
- Manual **Security** entries for coordinated disclosures / CVEs assigned post-commit
- Optional promotion of behavior-affecting refactors into **Improvements**
- **All tickets resolved** appendix check

Best merged together with or after #499, which introduces the sections this checklist curates.

QA-1674 status (updated after Daniel's comment on the ticket): mender/mender-connect/mender-binary-delta release together as the Mender Client from mender-client-subcomponents and don't use the 3C process — so no per-repo release-please there (earlier PRs closed). The client-side change is mendersoftware/mender-client-subcomponents#47, which ports the new cliff config used by the client changelog aggregator. `integration` gets nothing (no longer a customer-facing released component).

Ticket: [QA-1674](https://northerntech.atlassian.net/browse/QA-1674)

[QA-1674]: https://northerntech.atlassian.net/browse/QA-1674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ