### PR TITLE
ci: make sync:image track-agnostic for multiplatform builds

### DIFF
--- a/.gitlab-ci-check-docker-deploy.yml
+++ b/.gitlab-ci-check-docker-deploy.yml
@@ -58,6 +58,7 @@ sync:image:
     - if: '$CI_COMMIT_BRANCH == "master"'
   dependencies:
     - publish:image
+    - publish:image-multiplatform
   stage: sync
   image: registry.gitlab.com/northern.tech/mender/mender-test-containers/base-debian:master
   before_script:
@@ -74,6 +75,10 @@ sync:image:
     - git config --global user.email "mender@northern.tech"
     - git config --global user.name "Mender Test Bot"
   script:
+    - if [ -z "$PUBLISH_IMAGE_DIGEST" ]; then
+    -   echo "PUBLISH_IMAGE_DIGEST is empty, refusing to sync $TARGET_MANIFEST_FILE"
+    -   exit 1
+    - fi
     # Prepare temporary workspace
     - cd $(mktemp -d)
     - git clone --depth 1 ${INFRA_REPOSITORY} .


### PR DESCRIPTION
sync:image depended only on publish:image via `dependencies:`. Once a project disables publish:image in favor of publish:image-multiplatform (the pattern introduced by the previous two commits), that dependency job never runs, PUBLISH_IMAGE_DIGEST is never set, and sync:image silently commits a manifest with a blanked-out image: field to the target infra repo.

List both publish jobs under dependencies: so sync:image picks up whichever one actually ran, and add a guard that fails the job instead of pushing a broken manifest if the digest ends up empty anyway.

Ticket: QA-1487

Co-authored-with: Claude