### PR TITLE
ci: Setup specral fixed version for validate-open-api test

### DIFF
--- a/.gitlab-ci-check-apidocs.yml
+++ b/.gitlab-ci-check-apidocs.yml
@@ -61,10 +61,12 @@ test:validate-open-api:
   needs: []
   image:
     name: alpine
+  variables:
+    SPECTRAL_VERSION: "6.15.0"
   before_script:
     - apk --update add curl
     - curl -L https://raw.github.com/stoplightio/spectral/master/scripts/install.sh -o install.sh
-    - sh install.sh
+    - sh install.sh $SPECTRAL_VERSION
   script:
     - |
       cat > .spectral.yaml << EOF


### PR DESCRIPTION
This test failure is caused by malformed upstream spectral release: https://github.com/stoplightio/spectral/issues/2983