### PR TITLE
fix: adding missing quote

### DIFF
--- a/qa-common/retry.yml
+++ b/qa-common/retry.yml
@@ -114,6 +114,6 @@
     -   sleep 5
     - done
     - if [ "${DIND_ALIVE}" != "true" ]; then
-    -   echo "Dind service is down
+    -   echo "Dind service is down"
     -   exit 192
     - fi


### PR DESCRIPTION
Adds a missing closing quote in the `echo` statement of the dind health check in `qa-common/retry.yml`.