### PR TITLE
fix(changelog): end each release block with a trailing newline

### DIFF
--- a/utils/cliff.toml
+++ b/utils/cliff.toml
@@ -97,6 +97,8 @@ body = """
 
 No Changelog found.
 {% endif %}
+{%- raw %}
+{% endraw -%}
 """
 # template for the changelog footer
 footer = """---"""

--- a/utils/cliff.toml.scoped
+++ b/utils/cliff.toml.scoped
@@ -110,6 +110,8 @@ body = """
 
 No Changelog found.
 {% endif %}
+{%- raw %}
+{% endraw -%}
 """
 # template for the changelog footer
 footer = """---"""


### PR DESCRIPTION
Fast-follow fix for the config that went live in #504, reported on NorthernTechHQ/nt-gui#833: in a regenerated CHANGELOG, a release whose commits carry no tickets rendered its last bullet and the **next release's `##` header merged onto the same line** (`- Adjusted email endpoint## @northern.tech/store-0.41.0 - 2026-07-13`).

Root cause: git-cliff concatenates per-release body renders directly, and `trim = true` strips the template's own trailing newline — so a block only ended with a newline when the all-tickets appendix happened to render (its table rows carry one). Ticketless releases ended bare on the last bullet.

Fix: emit a trim-proof trailing newline (`{% raw %}`) at the end of the body template in both `cliff.toml` and `cliff.toml.scoped`, so every release block separates regardless of content.

Reproduced the nt-gui case locally (three-tag repo, middle release ticketless) — merged line before, clean separation after. Full 24-commit fixture suite passes for both configs.

Ticket: [QA-1670](https://northerntech.atlassian.net/browse/QA-1670)

[QA-1670]: https://northerntech.atlassian.net/browse/QA-1670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ