### PR TITLE
chore: ensure docker is ready for dind

### DIFF
--- a/.gitlab-ci-check-docker-build.yml
+++ b/.gitlab-ci-check-docker-build.yml
@@ -229,6 +229,8 @@ publish:image-multiplatform:
   dependencies:
     - build:docker-multiplatform
   before_script:
+    - *dind-config-create
+    - !reference [.qa-common-wait-for-dind, before_script]
     - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
     - *export_docker_vars
     - *docker_login_registries


### PR DESCRIPTION
Multiple publish:image-multiplatform have started failing with:
```
Failed to initialize: unable to resolve docker endpoint:
open /certs/client/ca.pem: no such file or directory
```
See 6d92a8913e5f975ae8f59091f3a6f0f8ae07fa61 for similar fixes