### PR TITLE
ci: use the codecov container for coverage uploads

### DIFF
--- a/.gitlab-ci-check-docker-acceptance.yml
+++ b/.gitlab-ci-check-docker-acceptance.yml
@@ -137,14 +137,10 @@ publish:acceptance:
     - if: '$CI_COMMIT_TAG =~ /^saas-[a-zA-Z0-9.]+$/'
       when: never
     - when: on_success
-  image: curlimages/curl-base
+  image: registry.gitlab.com/northern.tech/mender/mender-test-containers/codecov:master
   allow_failure: true
   script:
-    - curl -Os https://cli.codecov.io/latest/alpine/codecov
-    - curl -Os https://cli.codecov.io/latest/alpine/codecov.SHA256SUM
-    - sha256sum -c codecov.SHA256SUM
-    - chmod +x codecov
-    - ./codecov upload-process
+    - codecov upload-process
       --fail-on-error
       --git-service github
       --slug mendersoftware/${CI_PROJECT_NAME}

--- a/.gitlab-ci-check-golang-unittests-v2.yml
+++ b/.gitlab-ci-check-golang-unittests-v2.yml
@@ -75,15 +75,11 @@ publish:unittests:
     - if: '$CI_COMMIT_TAG =~ /^saas-[a-zA-Z0-9.]+$/'
       when: never
     - when: on_success
-  image: curlimages/curl-base
+  image: registry.gitlab.com/northern.tech/mender/mender-test-containers/codecov:master
   dependencies:
     - test:unit
   script:
-    - curl -Os https://cli.codecov.io/latest/alpine/codecov
-    - curl -Os https://cli.codecov.io/latest/alpine/codecov.SHA256SUM
-    - sha256sum -c codecov.SHA256SUM
-    - chmod +x codecov
-    - ./codecov upload-process
+    - codecov upload-process
       --fail-on-error
       --git-service github
       --slug mendersoftware/${CI_PROJECT_NAME}

--- a/.gitlab-ci-check-golang-unittests.yml
+++ b/.gitlab-ci-check-golang-unittests.yml
@@ -104,17 +104,13 @@ publish:unittests:
     - if: '$CI_COMMIT_TAG =~ /^saas-[a-zA-Z0-9.]+$/'
       when: never
     - when: on_success
-  image: curlimages/curl-base
+  image: registry.gitlab.com/northern.tech/mender/mender-test-containers/codecov:master
   allow_failure: true
   dependencies:
     - test:unit
   script:
     - tar -xvf unit-coverage.tar
-    - curl -Os https://cli.codecov.io/latest/alpine/codecov
-    - curl -Os https://cli.codecov.io/latest/alpine/codecov.SHA256SUM
-    - sha256sum -c codecov.SHA256SUM
-    - chmod +x codecov
-    - ./codecov upload-process
+    - codecov upload-process
       --fail-on-error
       --git-service github
       --slug mendersoftware/${CI_PROJECT_NAME}

--- a/templates/docker-acceptance-codecov.yml
+++ b/templates/docker-acceptance-codecov.yml
@@ -125,14 +125,10 @@ publish:acceptance:
     - if: '$CI_COMMIT_TAG =~ /^saas-[a-zA-Z0-9.]+$/'
       when: never
     - when: on_success
-  image: curlimages/curl-base
+  image: registry.gitlab.com/northern.tech/mender/mender-test-containers/codecov:master
   allow_failure: true
   script:
-    - curl -Os https://cli.codecov.io/latest/alpine/codecov
-    - curl -Os https://cli.codecov.io/latest/alpine/codecov.SHA256SUM
-    - sha256sum -c codecov.SHA256SUM
-    - chmod +x codecov
-    - ./codecov upload-process
+    - codecov upload-process
       --fail-on-error
       --git-service github
       --slug mendersoftware/${CI_PROJECT_NAME}

--- a/templates/golang-unittests-codecov.yml
+++ b/templates/golang-unittests-codecov.yml
@@ -105,17 +105,13 @@ publish:unittests:
     - if: '$CI_COMMIT_TAG =~ /^saas-[a-zA-Z0-9.]+$/'
       when: never
     - when: on_success
-  image: curlimages/curl-base
+  image: registry.gitlab.com/northern.tech/mender/mender-test-containers/codecov:master
   allow_failure: true
   dependencies:
     - test:unit
   script:
     - tar -xvf unit-coverage.tar
-    - curl -Os https://cli.codecov.io/latest/alpine/codecov
-    - curl -Os https://cli.codecov.io/latest/alpine/codecov.SHA256SUM
-    - sha256sum -c codecov.SHA256SUM
-    - chmod +x codecov
-    - ./codecov upload-process
+    - codecov upload-process
       --fail-on-error
       --git-service github
       --slug mendersoftware/${CI_PROJECT_NAME}

--- a/templates/golang-unittests-v2-codecov.yml
+++ b/templates/golang-unittests-v2-codecov.yml
@@ -74,15 +74,11 @@ publish:unittests:
     - if: '$CI_COMMIT_TAG =~ /^saas-[a-zA-Z0-9.]+$/'
       when: never
     - when: on_success
-  image: curlimages/curl-base
+  image: registry.gitlab.com/northern.tech/mender/mender-test-containers/codecov:master
   dependencies:
     - test:unit
   script:
-    - curl -Os https://cli.codecov.io/latest/alpine/codecov
-    - curl -Os https://cli.codecov.io/latest/alpine/codecov.SHA256SUM
-    - sha256sum -c codecov.SHA256SUM
-    - chmod +x codecov
-    - ./codecov upload-process
+    - codecov upload-process
       --fail-on-error
       --git-service github
       --slug mendersoftware/${CI_PROJECT_NAME}

--- a/templates/publish-codecov.yml
+++ b/templates/publish-codecov.yml
@@ -12,6 +12,9 @@ spec:
     runner:
       description: GitLab CI runner tag
       default: "k8s-small"
+    needs_job:
+      description: Name of the job producing the coverage file
+      default: "test:unit"
 ---
 
 publish:tests:
@@ -19,17 +22,13 @@ publish:tests:
     - $[[ inputs.runner ]]
   stage: $[[ inputs.stage ]]
   allow_failure: true
-  image: curlimages/curl-base
+  image: registry.gitlab.com/northern.tech/mender/mender-test-containers/codecov:master
   needs:
-    - job: test:unit
+    - job: $[[ inputs.needs_job ]]
       artifacts: true
   script:
-    - curl -Os https://cli.codecov.io/latest/alpine/codecov
-    - curl -Os https://cli.codecov.io/latest/alpine/codecov.SHA256SUM
-    - sha256sum -c codecov.SHA256SUM
-    - chmod +x codecov
     - PR_FLAG=$(echo "${CI_COMMIT_BRANCH}" | grep -q '^pr_' && echo "--pr $(echo "${CI_COMMIT_BRANCH}" | sed 's/^pr_//')" || echo "")
-    - ./codecov upload-process
+    - codecov upload-process
       --fail-on-error
       --git-service github
       --slug mendersoftware/${CI_PROJECT_NAME}


### PR DESCRIPTION
Every codecov job downloaded the CLI at runtime into a generic curl image, meaning an unpinned binary fetched on each pipeline run they now use the mender-test-containers codecov image

Also adds a `needs_job` input to publish-codecov because mender-flash produces coverage in `tests+coverage` rather than `test:unit`

Ticket: [QA-1573](https://northerntech.atlassian.net/browse/QA-1573)

[QA-1573]: https://northerntech.atlassian.net/browse/QA-1573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ